### PR TITLE
Add hook to always mark sandboxes for cleanup

### DIFF
--- a/tasks/aws_sandbox_cleanup.yml
+++ b/tasks/aws_sandbox_cleanup.yml
@@ -1,0 +1,131 @@
+---
+- name: Ensure mandatory variables are set
+  assert:
+    that: "{{ check.that }}"
+    fail_msg: "{{ check.msg }}"
+    quiet: true
+  loop_control:
+    loop_var: check
+    label: "{{ check.msg }}"
+  loop:
+    - msg: anarchy variables must be defined, are we running in Anarchy?
+      that:
+        # Check for anarchy_governor and anarchy_subject, but be careful not to trigger template
+        # evaluation. These often will contain variable references that cannot be resolved by
+        # anarchy but will later be resolved within the deployer job.
+        - vars.anarchy_governor is defined
+        - vars.anarchy_subject is defined
+
+    - msg: Variable guid is not defined
+      that: >-
+        vars.anarchy_subject.vars.job_vars.guid is defined
+        and vars.anarchy_subject.vars.job_vars.guid != ''
+
+    - msg: Variable uuid is not defined
+      that: >-
+        vars.anarchy_subject.vars.job_vars.uuid is defined
+        and vars.anarchy_subject.vars.job_vars.uuid != ''
+
+    - msg: Variable aws_sandbox_manager is not defined
+      that: aws_sandbox_manager is defined
+
+    - msg: Variable aws_sandbox_manager is incomplete ; missing AWS credentials
+      that: >-
+        'pool_manager_aws_access_key_id' in aws_sandbox_manager
+        and 'pool_manager_aws_secret_access_key' in aws_sandbox_manager
+
+- environment:
+    AWS_ACCESS_KEY_ID: "{{ aws_sandbox_manager.pool_manager_aws_access_key_id }}"
+    AWS_SECRET_ACCESS_KEY: "{{ aws_sandbox_manager.pool_manager_aws_secret_access_key }}"
+  block:
+    - name: Check if sandbox is associated
+      vars:
+        _expression: >-
+          available = :a
+          and guid = :g
+          and ( attribute_not_exists(service_uuid) or service_uuid = :u )
+        _data:
+          ":a":
+            BOOL: false
+          ":g":
+            S: "{{ vars.anarchy_subject.vars.job_vars.guid }}"
+          ":u":
+            S: "{{ vars.anarchy_subject.vars.job_vars.uuid }}"
+      command: >-
+        aws
+        --region "{{ aws_sandbox_manager.pool_region | default('us-east-1') }}"
+        dynamodb scan
+        --table-name {{ aws_sandbox_manager.pool_table | default('accounts') }}
+        --filter-expression '{{ _expression }}'
+        --expression-attribute-values '{{ _data | to_json }}'
+        --max-item 1
+      register: r_associated
+
+    - set_fact:
+        query1: "{{ r_associated.stdout | from_json }}"
+
+    - when: query1.Count == 1
+      block:
+        - debug:
+            msg: >-
+              guid={{ vars.anarchy_subject.vars.job_vars.guid }}
+              uuid={{ vars.anarchy_subject.vars.job_vars.uuid }}
+              {{ query1.Items[0].name.S }} found"
+
+        - name: Save sandbox variables
+          set_fact:
+            sandbox_name: "{{ query1.Items[0].name.S }}"
+
+        - name: Mark the sandbox for cleanup
+          vars:
+            _data:
+              ":cl":
+                BOOL: true
+              ":currval":
+                BOOL: false
+              ":av":
+                BOOL: false
+              ":g":
+                S: "{{ vars.anarchy_subject.vars.job_vars.guid }}"
+              ":u":
+                S: "{{ vars.anarchy_subject.vars.job_vars.uuid }}"
+          command: >-
+            aws
+            --region "{{ aws_sandbox_manager.pool_region | default('us-east-1') }}"
+            dynamodb update-item
+            --table-name {{ aws_sandbox_manager.pool_table | default('accounts') }}
+            --key "{\"name\": {\"S\": \"{{ sandbox_name }}\"}}"
+            --update-expression "SET to_cleanup = :cl"
+            --condition-expression "available = :av
+            and guid = :g
+            and ( attribute_not_exists(service_uuid) or service_uuid = :u )
+            and to_cleanup = :currval
+            "
+            --expression-attribute-values '{{ _data | to_json }}'
+
+          register: r_mark
+          changed_when: r_mark.rc == 0
+
+          # When an update-item request fails with 'The conditional request failed' error message,
+          # it means the condition expression wasn't true and the item was not updated.
+          # In the condition-expression above, before marking for cleanup,
+          # we make sure:
+          # - sandbox is not available (taken)
+          # - associated to the guid and uuid
+          # - to_cleanup is false
+          #
+          # if the conditional expression did not pass, it means, between the previous request and this one:
+          # the sandbox's been cleaned up already => All good
+          # OR the sandbox is already marked for cleanup => All good
+          #
+          # That's why we set the failed_when as follow:
+          failed_when: >-
+            r_mark.rc != 0
+            and  'The conditional request failed' not in r_mark.stdout
+
+    - when: query1.Count == 0
+      debug:
+        msg: >-
+          guid={{ vars.anarchy_subject.vars.job_vars.guid }}
+          uuid={{ vars.anarchy_subject.vars.job_vars.uuid }}
+          sandbox not found"

--- a/tasks/aws_sandbox_cleanup.yml
+++ b/tasks/aws_sandbox_cleanup.yml
@@ -71,7 +71,7 @@
             msg: >-
               guid={{ vars.anarchy_subject.vars.job_vars.guid }}
               uuid={{ vars.anarchy_subject.vars.job_vars.uuid }}
-              {{ query1.Items[0].name.S }} found"
+              {{ query1.Items[0].name.S }} found
 
         - name: Save sandbox variables
           set_fact:
@@ -129,4 +129,4 @@
         msg: >-
           guid={{ vars.anarchy_subject.vars.job_vars.guid }}
           uuid={{ vars.anarchy_subject.vars.job_vars.uuid }}
-          sandbox not found"
+          sandbox not found

--- a/tasks/aws_sandbox_cleanup.yml
+++ b/tasks/aws_sandbox_cleanup.yml
@@ -111,9 +111,9 @@
           # it means the condition expression wasn't true and the item was not updated.
           # In the condition-expression above, before marking for cleanup,
           # we make sure:
-          # - sandbox is not available (taken)
-          # - associated to the guid and uuid
-          # - to_cleanup is false
+          # - the sandbox is not available (taken)
+          # - the sandbox is associated to the guid and uuid
+          # - the sandbox is not marked for cleanup (to_cleanup is false)
           #
           # if the conditional expression did not pass, it means, between the previous request and this one:
           # the sandbox's been cleaned up already => All good

--- a/tasks/aws_sandbox_cleanup.yml
+++ b/tasks/aws_sandbox_cleanup.yml
@@ -60,6 +60,7 @@
         --expression-attribute-values '{{ _data | to_json }}'
         --max-item 1
       register: r_associated
+      changed_when: false
 
     - set_fact:
         query1: "{{ r_associated.stdout | from_json }}"
@@ -121,7 +122,7 @@
           # That's why we set the failed_when as follow:
           failed_when: >-
             r_mark.rc != 0
-            and  'The conditional request failed' not in r_mark.stdout
+            and  'ConditionalCheckFailedException' not in r_mark.stderr
 
     - when: query1.Count == 0
       debug:

--- a/tasks/handle-action-destroy-complete.yaml
+++ b/tasks/handle-action-destroy-complete.yaml
@@ -1,4 +1,10 @@
 ---
+- when: >-
+    vars.anarchy_subject.vars.job_vars.__meta__.aws_sandboxed | default(false)
+    or
+    vars.anarchy_governor.vars.job_vars.__meta__.aws_sandboxed | default(false)
+  include_tasks: aws_sandbox_cleanup.yml
+
 - name: Complete AnarchySubject deletion
   anarchy_subject_delete:
     remove_finalizers: true

--- a/tasks/handle-action-destroy-complete.yaml
+++ b/tasks/handle-action-destroy-complete.yaml
@@ -1,8 +1,5 @@
 ---
-- when: >-
-    vars.anarchy_subject.vars.job_vars.__meta__.aws_sandboxed | default(false)
-    or
-    vars.anarchy_governor.vars.job_vars.__meta__.aws_sandboxed | default(false)
+- when: vars.anarchy_governor.vars.job_vars.__meta__.aws_sandboxed | default(false)
   include_tasks: aws_sandbox_cleanup.yml
 
 - name: Complete AnarchySubject deletion


### PR DESCRIPTION
This change, if applied, adds a hook before deleting any Anarchy Subject to ensure the AWS sandbox associated with the Subject is marked for cleanup.

The tasks should be idem potent and not do anything (no "update" tasks, just "ok" tasks) if
- no sandbox associated to the uuid or guid is found
- the sandbox is already marked for cleanup
- the sandbox has been released since

Thus those tasks should be compatible with the babylon_aws_sandbox role and can be run in addition to that role.
Theyl act as a fail-safe.

Some questions for @jkupferer :

- What happens if the task fails? The anarchy Subject will stay hanging? Will delete be retried automatically? Answered. => yes.

- Is it OK to increase work done at the destroy-complete level?
  Any impact on performance for example if we delete subjet or claim resources in big batches? Answered. => No performance issue, should be negligible.

- Can a user forge a Subject and:
  set the UUID to someone's else
  set aws_sandboxed=true
  then delete the subject and thus clean up someone's else sandbox?
  
  In other words:
  ~Should we look only at `vars.anarchy_governor.vars.job_vars.__meta__.aws_sandboxed` as the hook condition?~  Answered. => yes.


see GPTEINFRA-5488