### PR TITLE
Roll out sandbox API to stop/start open environments

### DIFF
--- a/defaults/main.yaml
+++ b/defaults/main.yaml
@@ -150,3 +150,5 @@ sandbox_api_url: >-
   | default('http://sandbox-api.babylon-sandbox-api.svc.cluster.local:8080') }}
 sandbox_api_retries: 10
 sandbox_api_delay: 30
+
+now_time_utc: "{{ now(utc=true, fmt='%Y-%m-%dT%H:%M:%S') }}"

--- a/tasks/handle-action-start.yaml
+++ b/tasks/handle-action-start.yaml
@@ -1,6 +1,19 @@
 ---
+# Use the sandbox API to start environments if
+# __meta__.sandbox_api.actions.start is non empty
+- name: start {{ anarchy_subject_name }} with Sandbox API
+  when: >-
+    __meta__.sandbox_api.actions.start | default({}) | length > 0
+    and current_state != "starting"
+    and sandbox_api_login_token | default("") != ""
+  block:
+    - include_tasks: sandbox_api_login.yaml
+    - include_tasks: sandbox_api_start.yaml
+
 - name: Start {{ anarchy_subject_name }}
-  when: current_state != "starting"
+  when: >-
+    __meta__.sandbox_api.actions.start | default({}) | length == 0
+    and current_state != "starting"
   include_tasks: run-start.yaml
 
 - name: Check start of {{ anarchy_subject_name }}

--- a/tasks/handle-action-stop.yaml
+++ b/tasks/handle-action-stop.yaml
@@ -1,6 +1,19 @@
 ---
+# Use the sandbox API to stop environments if
+# __meta__.sandbox_api.actions.stop is non empty
+- name: Stop {{ anarchy_subject_name }} with Sandbox API
+  when: >-
+    __meta__.sandbox_api.actions.stop | default({}) | length > 0
+    and current_state != "stopping"
+    and sandbox_api_login_token | default("") != ""
+  block:
+    - include_tasks: sandbox_api_login.yaml
+    - include_tasks: sandbox_api_stop.yaml
+
 - name: Stop {{ anarchy_subject_name }}
-  when: current_state != "stopping"
+  when: >-
+    __meta__.sandbox_api.actions.stop | default({}) | length == 0
+    and current_state != "stopping"
   include_tasks: run-stop.yaml
 
 - name: Check stop of {{ anarchy_subject_name }}

--- a/tasks/sandbox_api_start.yaml
+++ b/tasks/sandbox_api_start.yaml
@@ -1,0 +1,90 @@
+---
+- block:
+  - name: Start service using the Sandbox API
+    uri:
+      headers:
+        Authorization: Bearer {{ access_token }}
+      url: "{{ sandbox_api_url }}/api/v1/placements/{{ uuid }}/start"
+      body_format: json
+      method: PUT
+      status_code: [200, 202]
+    register: r_start
+    retries: "{{ sandbox_api_retries }}"
+    delay: "{{ sandbox_api_delay }}"
+    until: r_start is succeeded or r_start.status == 404
+
+  - name: Set status in anarchy subject
+    anarchy_subject_update:
+      skip_update_processing: true
+      metadata:
+        labels:
+          state: "starting"
+      spec:
+        vars:
+          current_state: "starting"
+      status:
+        sandboxAPIJobs:
+          start:
+            requestID: "{{ r_start.json.request_id }}"
+            message: "{{ r_start.json.message }}"
+            startTimestamp: "{{ now_time_utc }}"
+
+  - name: Wait until async job is completed
+    uri:
+      headers:
+        Authorization: Bearer {{ access_token }}
+      url: "{{ sandbox_api_url }}/api/v1/requests/{{ r_start.json.request_id }}/status"
+      body_format: json
+      status_code: 200
+    register: r_request
+    retries: "{{ sandbox_api_retries }}"
+    delay: "{{ sandbox_api_delay }}"
+    failed_when: >-
+      r_request is failed
+      or r_request.json.status | default('unknown') == 'error'
+    until: >-
+      r_request is succeeded
+      and r_request.json.status not in ["unknown", "running", "new", "initializing", "initialized"]
+
+  - when: r_request.json.status == "success"
+    block:
+    - name: Set state started for {{ anarchy_subject_name }}
+      anarchy_subject_update:
+        metadata:
+          labels:
+            state: started
+        spec:
+          vars:
+            current_state: started
+        status:
+          sandboxAPIJobs:
+            start:
+              completeTimestamp: "{{ now_time_utc }}"
+              jobStatus: successful
+              Message: r_request.json.message
+
+    - name: Report action successful
+      anarchy_finish_action:
+        state: successful
+
+  rescue:
+  - name: Set state start-error for {{ anarchy_subject_name }}
+    anarchy_subject_update:
+      metadata:
+        labels:
+          state: start-error
+      spec:
+        vars:
+          current_state: start-error
+          healthy: false
+      status:
+        sandboxAPIJobs:
+          start:
+            completeTimestamp: "{{ now_time_utc }}"
+            jobStatus: error
+            Message: r_request.json.message
+
+  - name: Report action successful
+    anarchy_finish_action:
+      state: error
+...

--- a/tasks/sandbox_api_stop.yaml
+++ b/tasks/sandbox_api_stop.yaml
@@ -1,0 +1,90 @@
+---
+- block:
+  - name: Stop service using the Sandbox API
+    uri:
+      headers:
+        Authorization: Bearer {{ access_token }}
+      url: "{{ sandbox_api_url }}/api/v1/placements/{{ uuid }}/stop"
+      body_format: json
+      method: PUT
+      status_code: [200, 202]
+    register: r_stop
+    retries: "{{ sandbox_api_retries }}"
+    delay: "{{ sandbox_api_delay }}"
+    until: r_stop is succeeded or r_start.status == 404
+
+  - name: Set status in anarchy subject
+    anarchy_subject_update:
+      skip_update_processing: true
+      metadata:
+        labels:
+          state: "stopping"
+      spec:
+        vars:
+          current_state: "stopping"
+      status:
+        sandboxAPIJobs:
+          stop:
+            requestID: "{{ r_stop.json.request_id }}"
+            message: "{{ r_stop.json.message }}"
+            startTimestamp: "{{ now_time_utc }}"
+
+  - name: Wait until async job is completed
+    uri:
+      headers:
+        Authorization: Bearer {{ access_token }}
+      url: "{{ sandbox_api_url }}/api/v1/requests/{{ r_stop.json.request_id }}/status"
+      body_format: json
+      status_code: 200
+    register: r_request
+    retries: "{{ sandbox_api_retries }}"
+    delay: "{{ sandbox_api_delay }}"
+    failed_when: >-
+      r_request is failed
+      or r_request.json.status | default('unknown') == 'error'
+    until: >-
+      r_request is succeeded
+      and r_request.json.status not in ["unknown", "running", "new", "initializing", "initialized"]
+
+  - when: r_request.json.status == "success"
+    block:
+    - name: Set state stopped for {{ anarchy_subject_name }}
+      anarchy_subject_update:
+        metadata:
+          labels:
+            state: stopped
+        spec:
+          vars:
+            current_state: stopped
+        status:
+          sandboxAPIJobs:
+            stop:
+              completeTimestamp: "{{ now_time_utc }}"
+              jobStatus: successful
+              Message: r_request.json.message
+
+    - name: Report action successful
+      anarchy_finish_action:
+        state: successful
+
+  rescue:
+  - name: Set state stop-error for {{ anarchy_subject_name }}
+    anarchy_subject_update:
+      metadata:
+        labels:
+          state: stop-error
+      spec:
+        vars:
+          current_state: stop-error
+          healthy: false
+      status:
+        sandboxAPIJobs:
+          stop:
+            completeTimestamp: "{{ now_time_utc }}"
+            jobStatus: error
+            Message: r_request.json.message
+
+  - name: Report action successful
+    anarchy_finish_action:
+      state: error
+...


### PR DESCRIPTION
jira: GPTEINFRA-6598 

This update introduces the functionality to utilize the sandbox API for generic stop/start operations, allowing us to manage services within environments whose contents are not known.

To activate this feature, the catalog item maintainer must configure the following in agnosticv:

```yaml
__meta__:
  sandbox_api:
    actions:
      stop:
        enable: true
      start:
        enable: true
```

When above block is present, the Sandbox API actions takes precedence over the deployer actions.

The service is stopped using the `/placements/{uuid}/stop` endpoint, and the `/requests/{request_id}/status` endpoint is monitored to confirm the completion of the operation. As this process only takes a few seconds, i think it's appropriate to maintain it within the same task file, rather than initiating another anarchy run.

Error handling is managed through the use of Ansible's block/rescue structure.