### PR TITLE
Handle sandbox-api job errors and fix ansible syntax for status.sandboxAPIJobs

### DIFF
--- a/tasks/sandbox_api_start.yaml
+++ b/tasks/sandbox_api_start.yaml
@@ -61,7 +61,7 @@
             start:
               completeTimestamp: "{{ now_time_utc }}"
               jobStatus: successful
-              Message: r_request.json.message
+              message: "{{ r_request.json.message | default('') }}"
 
     - name: Report action successful
       anarchy_finish_action:
@@ -82,7 +82,7 @@
           start:
             completeTimestamp: "{{ now_time_utc }}"
             jobStatus: error
-            Message: r_request.json.message
+            message: "{{ r_request.json.message | default('') }}"
 
   - name: Report action successful
     anarchy_finish_action:

--- a/tasks/sandbox_api_start.yaml
+++ b/tasks/sandbox_api_start.yaml
@@ -61,7 +61,8 @@
             start:
               completeTimestamp: "{{ now_time_utc }}"
               jobStatus: successful
-              message: "{{ r_request.json.message | default('') }}"
+              httpStatus: "{{ r_request.status }}"
+              message: "{{ r_request.json.message | default(r_request.msg) }}"
 
     - name: Report action successful
       anarchy_finish_action:
@@ -82,7 +83,8 @@
             start:
               completeTimestamp: "{{ now_time_utc }}"
               jobStatus: error
-              message: "{{ r_request.json.message | default('') }}"
+              httpStatus: "{{ r_request.status }}"
+              message: "{{ r_request.json.message | default(r_request.msg) }}"
 
     - name: Report action failure
       anarchy_finish_action:
@@ -103,7 +105,8 @@
           start:
             completeTimestamp: "{{ now_time_utc }}"
             jobStatus: error
-            message: "{{ r_request.json.message | default('') }}"
+            httpStatus: "{{ r_request.status }}"
+            message: "{{ r_request.json.message | default(r_request.msg) }}"
 
   - name: Report action failure
     anarchy_finish_action:

--- a/tasks/sandbox_api_start.yaml
+++ b/tasks/sandbox_api_start.yaml
@@ -44,7 +44,7 @@
       or r_request.json.status | default('unknown') == 'error'
     until: >-
       r_request is succeeded
-      and r_request.json.status not in ["unknown", "running", "new", "initializing", "initialized"]
+      and r_request.json.status in ["success", "error"]
 
   - when: r_request.json.status == "success"
     block:
@@ -66,6 +66,27 @@
     - name: Report action successful
       anarchy_finish_action:
         state: successful
+
+  - when: r_request.json.status == "error"
+    block:
+    - name: Set state started for {{ anarchy_subject_name }}
+      anarchy_subject_update:
+        metadata:
+          labels:
+            state: start-error
+        spec:
+          vars:
+            current_state: start-error
+        status:
+          sandboxAPIJobs:
+            start:
+              completeTimestamp: "{{ now_time_utc }}"
+              jobStatus: error
+              message: "{{ r_request.json.message | default('') }}"
+
+    - name: Report action successful
+      anarchy_finish_action:
+        state: error
 
   rescue:
   - name: Set state start-error for {{ anarchy_subject_name }}

--- a/tasks/sandbox_api_start.yaml
+++ b/tasks/sandbox_api_start.yaml
@@ -28,6 +28,7 @@
             requestID: "{{ r_start.json.request_id }}"
             message: "{{ r_start.json.message }}"
             startTimestamp: "{{ now_time_utc }}"
+            httpStatus: "{{ r_start.status }}"
 
   - name: Wait until async job is completed
     uri:

--- a/tasks/sandbox_api_start.yaml
+++ b/tasks/sandbox_api_start.yaml
@@ -84,7 +84,7 @@
               jobStatus: error
               message: "{{ r_request.json.message | default('') }}"
 
-    - name: Report action successful
+    - name: Report action failure
       anarchy_finish_action:
         state: error
 
@@ -105,7 +105,7 @@
             jobStatus: error
             message: "{{ r_request.json.message | default('') }}"
 
-  - name: Report action successful
+  - name: Report action failure
     anarchy_finish_action:
       state: error
 ...

--- a/tasks/sandbox_api_start.yaml
+++ b/tasks/sandbox_api_start.yaml
@@ -70,7 +70,7 @@
 
   - when: r_request.json.status == "error"
     block:
-    - name: Set state started for {{ anarchy_subject_name }}
+    - name: Set state start-error for {{ anarchy_subject_name }}
       anarchy_subject_update:
         metadata:
           labels:

--- a/tasks/sandbox_api_start.yaml
+++ b/tasks/sandbox_api_start.yaml
@@ -62,7 +62,6 @@
               completeTimestamp: "{{ now_time_utc }}"
               jobStatus: successful
               httpStatus: "{{ r_request.status }}"
-              message: "{{ r_request.json.message | default(r_request.msg) }}"
 
     - name: Report action successful
       anarchy_finish_action:
@@ -84,7 +83,6 @@
               completeTimestamp: "{{ now_time_utc }}"
               jobStatus: error
               httpStatus: "{{ r_request.status }}"
-              message: "{{ r_request.json.message | default(r_request.msg) }}"
 
     - name: Report action failure
       anarchy_finish_action:
@@ -105,8 +103,17 @@
           start:
             completeTimestamp: "{{ now_time_utc }}"
             jobStatus: error
-            httpStatus: "{{ r_request.status }}"
-            message: "{{ r_request.json.message | default(r_request.msg) }}"
+            httpStatus: >-
+              {{ r_request.status
+              | default(r_start.status)
+              }}
+            message: >-
+              {{ r_request.json.message
+              | default(r_request.msg, true)
+              | default(r_start.json.message, true)
+              | default(r_start.msg, true)
+              | default("something bad happened")
+              }}
 
   - name: Report action failure
     anarchy_finish_action:

--- a/tasks/sandbox_api_stop.yaml
+++ b/tasks/sandbox_api_stop.yaml
@@ -61,7 +61,8 @@
             stop:
               completeTimestamp: "{{ now_time_utc }}"
               jobStatus: successful
-              message: "{{ r_request.json.message | default('') }}"
+              httpStatus: "{{ r_request.status }}"
+              message: "{{ r_request.json.message | default(r_request.msg) }}"
 
     - name: Report action successful
       anarchy_finish_action:
@@ -82,7 +83,8 @@
             stop:
               completeTimestamp: "{{ now_time_utc }}"
               jobStatus: error
-              message: "{{ r_request.json.message | default('') }}"
+              httpStatus: "{{ r_request.status }}"
+              message: "{{ r_request.json.message | default(r_request.msg) }}"
 
     - name: Report action failure
       anarchy_finish_action:
@@ -103,7 +105,8 @@
           stop:
             completeTimestamp: "{{ now_time_utc }}"
             jobStatus: error
-            message: "{{ r_request.json.message | default('') }}"
+            httpStatus: "{{ r_request.status }}"
+            message: "{{ r_request.json.message | default(r_request.msg) }}"
 
   - name: Report action failure
     anarchy_finish_action:

--- a/tasks/sandbox_api_stop.yaml
+++ b/tasks/sandbox_api_stop.yaml
@@ -61,7 +61,7 @@
             stop:
               completeTimestamp: "{{ now_time_utc }}"
               jobStatus: successful
-              Message: r_request.json.message
+              message: "{{ r_request.json.message | default('') }}"
 
     - name: Report action successful
       anarchy_finish_action:
@@ -82,7 +82,7 @@
           stop:
             completeTimestamp: "{{ now_time_utc }}"
             jobStatus: error
-            Message: r_request.json.message
+            message: "{{ r_request.json.message | default('') }}"
 
   - name: Report action successful
     anarchy_finish_action:

--- a/tasks/sandbox_api_stop.yaml
+++ b/tasks/sandbox_api_stop.yaml
@@ -28,6 +28,7 @@
             requestID: "{{ r_stop.json.request_id }}"
             message: "{{ r_stop.json.message }}"
             startTimestamp: "{{ now_time_utc }}"
+            httpStatus: "{{ r_stop.status }}"
 
   - name: Wait until async job is completed
     uri:

--- a/tasks/sandbox_api_stop.yaml
+++ b/tasks/sandbox_api_stop.yaml
@@ -62,7 +62,6 @@
               completeTimestamp: "{{ now_time_utc }}"
               jobStatus: successful
               httpStatus: "{{ r_request.status }}"
-              message: "{{ r_request.json.message | default(r_request.msg) }}"
 
     - name: Report action successful
       anarchy_finish_action:
@@ -84,7 +83,6 @@
               completeTimestamp: "{{ now_time_utc }}"
               jobStatus: error
               httpStatus: "{{ r_request.status }}"
-              message: "{{ r_request.json.message | default(r_request.msg) }}"
 
     - name: Report action failure
       anarchy_finish_action:
@@ -105,8 +103,17 @@
           stop:
             completeTimestamp: "{{ now_time_utc }}"
             jobStatus: error
-            httpStatus: "{{ r_request.status }}"
-            message: "{{ r_request.json.message | default(r_request.msg) }}"
+            httpStatus: >-
+              {{ r_request.status
+              | default(r_stop.status)
+              }}
+            message: >-
+              {{ r_request.json.message
+              | default(r_request.msg, true)
+              | default(r_stop.json.message, true)
+              | default(r_stop.msg, true)
+              | default("something bad happened")
+              }}
 
   - name: Report action failure
     anarchy_finish_action:

--- a/tasks/sandbox_api_stop.yaml
+++ b/tasks/sandbox_api_stop.yaml
@@ -44,7 +44,7 @@
       or r_request.json.status | default('unknown') == 'error'
     until: >-
       r_request is succeeded
-      and r_request.json.status not in ["unknown", "running", "new", "initializing", "initialized"]
+      and r_request.json.status in ["success", "error"]
 
   - when: r_request.json.status == "success"
     block:
@@ -66,6 +66,27 @@
     - name: Report action successful
       anarchy_finish_action:
         state: successful
+
+  - when: r_request.json.status == "error"
+    block:
+    - name: Set state started for {{ anarchy_subject_name }}
+      anarchy_subject_update:
+        metadata:
+          labels:
+            state: stop-error
+        spec:
+          vars:
+            current_state: stop-error
+        status:
+          sandboxAPIJobs:
+            stop:
+              completeTimestamp: "{{ now_time_utc }}"
+              jobStatus: error
+              message: "{{ r_request.json.message | default('') }}"
+
+    - name: Report action successful
+      anarchy_finish_action:
+        state: error
 
   rescue:
   - name: Set state stop-error for {{ anarchy_subject_name }}

--- a/tasks/sandbox_api_stop.yaml
+++ b/tasks/sandbox_api_stop.yaml
@@ -11,7 +11,7 @@
     register: r_stop
     retries: "{{ sandbox_api_retries }}"
     delay: "{{ sandbox_api_delay }}"
-    until: r_stop is succeeded or r_start.status == 404
+    until: r_stop is succeeded or r_stop.status == 404
 
   - name: Set status in anarchy subject
     anarchy_subject_update:
@@ -70,7 +70,7 @@
 
   - when: r_request.json.status == "error"
     block:
-    - name: Set state started for {{ anarchy_subject_name }}
+    - name: Set state stop-error for {{ anarchy_subject_name }}
       anarchy_subject_update:
         metadata:
           labels:

--- a/tasks/sandbox_api_stop.yaml
+++ b/tasks/sandbox_api_stop.yaml
@@ -84,7 +84,7 @@
               jobStatus: error
               message: "{{ r_request.json.message | default('') }}"
 
-    - name: Report action successful
+    - name: Report action failure
       anarchy_finish_action:
         state: error
 
@@ -105,7 +105,7 @@
             jobStatus: error
             message: "{{ r_request.json.message | default('') }}"
 
-  - name: Report action successful
+  - name: Report action failure
     anarchy_finish_action:
       state: error
 ...


### PR DESCRIPTION
- Add case to deal with job errors
- fix camelCase 'Message' -> 'message'
- use a default empty string in case the request failed or doesn't have a message
- Add also  `msg` and `status` from the `uri` ansible module to `status.sandboxAPIJob` 

GPTEINFRA-7351