### PR TITLE
status can be different than success/error

### DIFF
--- a/tasks/sandbox_api_start.yaml
+++ b/tasks/sandbox_api_start.yaml
@@ -68,7 +68,7 @@
       anarchy_finish_action:
         state: successful
 
-  - when: r_request.json.status == "error"
+  - when: r_request.json.status != "success"
     block:
     - name: Set state start-error for {{ anarchy_subject_name }}
       anarchy_subject_update:

--- a/tasks/sandbox_api_stop.yaml
+++ b/tasks/sandbox_api_stop.yaml
@@ -68,7 +68,7 @@
       anarchy_finish_action:
         state: successful
 
-  - when: r_request.json.status == "error"
+  - when: r_request.json.status != "success"
     block:
     - name: Set state stop-error for {{ anarchy_subject_name }}
       anarchy_subject_update:


### PR DESCRIPTION
This fix cases where a job is stuck as 'new' for example.