### PR TITLE
Merge rhpds/babylon_aws_sandbox into anarchy governor role

### DIFF
--- a/defaults/main.yaml
+++ b/defaults/main.yaml
@@ -1,4 +1,28 @@
 ---
+# Variables from Anarchy Subject
+guid: "{{ vars.anarchy_subject.vars.job_vars.guid | default(None) }}"
+
+# Variables from Anarchy Subject
+uuid: "{{ vars.anarchy_subject.vars.job_vars.uuid | default(None) }}"
+
+# Variables from either Governor or Subject
+env_type: >-
+  {{ vars.anarchy_governor.vars.job_vars.env_type
+  | default(vars.anarchy_subject.vars.job_vars.env_type)
+  | default(None) }}
+
+requester_email: >-
+  {{ vars.anarchy_subject.metadata.annotations['poolboy.gpte.redhat.com/resource-requester-email']
+  | default(vars.anarchy_subject.vars.job_vars.requester_email)
+  | default(vars.anarchy_subject.vars.job_vars.email)
+  | default(None) }}
+
+requester_user: >-
+  {{ vars.anarchy_subject.metadata.annotations['poolboy.gpte.redhat.com/resource-requester-user']
+  | default(vars.anarchy_subject.vars.job_vars.requester_username)
+  | default(vars.anarchy_subject.vars.job_vars.student_name)
+  | default('babylon') }}
+
 delete_on_failure: true
 
 action_provision_data: "{{ anarchy_action_callback_data.data | default({}) }}"
@@ -142,7 +166,25 @@ deployer_entry_points:
 static_credentials: >-
   {{ __meta__.deployer.credentials | default([]) }}
 
+################################
 # Sandbox API
+################################
+sandbox_api_in_use: >-
+  {{
+    vars.anarchy_subject.vars.job_vars.__meta__.aws_sandboxed | default(false)
+    or
+    vars.anarchy_governor.vars.job_vars.__meta__.aws_sandboxed | default(false)
+    or
+    vars.anarchy_governor.vars.job_vars.__meta__.sandbox_api.resources
+    | default(vars.anarchy_subject.vars.__meta__.sandbox_api.resources)
+    | default([])
+    | length > 0
+  }}
+
+# minimum age the sandbox must be before it's selected from the pool
+# default is 24h
+babylon_aws_sandbox_min_age: "{{ 3600 * 24 }}"
+
 sandbox_api_login_token: "{{ sandbox_api.sandbox_api_login_token }}"
 
 sandbox_api_url: >-
@@ -152,3 +194,34 @@ sandbox_api_retries: 10
 sandbox_api_delay: 30
 
 now_time_utc: "{{ now(utc=true, fmt='%Y-%m-%dT%H:%M:%S') }}"
+
+# Variables from secret via the aws_sandbox_manager variable
+dynamodb_pool_table: "{{ aws_sandbox_manager.pool_table | default('accounts') }}"
+dynamodb_pool_region: "{{ aws_sandbox_manager.pool_region | default('us-east-1') }}"
+pool_manager_aws_access_key_id: "{{ aws_sandbox_manager.pool_manager_aws_access_key_id | default(None) }}"
+pool_manager_aws_secret_access_key: "{{ aws_sandbox_manager.pool_manager_aws_secret_access_key | default(None) }}"
+pool_manager_vault_password: "{{ aws_sandbox_manager.pool_manager_vault_password | default(None) }}"
+
+# Reservation
+sandbox_api_reservation: >-
+  {{ vars.anarchy_governor.vars.job_vars.__meta__.sandbox_api.reservation
+  | default(vars.anarchy_subject.vars.__meta__.sandbox_api.reservation)
+  | default("") }}
+
+# Control wether the Sandbox API is enough to cleanup everything. By default, it's true.
+# It means if the deployer fails in AAP, it'll be ignored and the sandbox API will cleanup everything after and the AnarchySubject will be deleted
+# If the Controller job must succeed for a service to be considered delete, turn this to false in agnosticv __meta__.sandbox_api.destroy_catch_all
+sandbox_api_destroy_catch_all: >-
+  {{ vars.anarchy_governor.vars.job_vars.__meta__.sandbox_api.destroy_catch_all
+  | default(vars.anarchy_subject.vars.__meta__.sandbox_api.destroy_catch_all)
+  | default(true) }}
+
+sandbox_api_resources_default:
+- kind: AwsSandbox
+  count: 1
+
+# Kind of resources to book
+sandbox_api_resources: >-
+  {{ vars.anarchy_governor.vars.job_vars.__meta__.sandbox_api.resources
+  | default(vars.anarchy_subject.vars.__meta__.sandbox_api.resources)
+  | default(sandbox_api_resources_default) }}

--- a/defaults/main.yaml
+++ b/defaults/main.yaml
@@ -21,7 +21,7 @@ requester_user: >-
   {{ vars.anarchy_subject.metadata.annotations['poolboy.gpte.redhat.com/resource-requester-user']
   | default(vars.anarchy_subject.vars.job_vars.requester_username)
   | default(vars.anarchy_subject.vars.job_vars.student_name)
-  | default('babylon') }}
+  | default('babylon', true) }}
 
 delete_on_failure: true
 

--- a/defaults/main.yaml
+++ b/defaults/main.yaml
@@ -171,12 +171,9 @@ static_credentials: >-
 ################################
 sandbox_api_in_use: >-
   {{
-    vars.anarchy_subject.vars.job_vars.__meta__.aws_sandboxed | default(false)
-    or
     vars.anarchy_governor.vars.job_vars.__meta__.aws_sandboxed | default(false)
     or
-    vars.anarchy_governor.vars.job_vars.__meta__.sandbox_api.resources
-    | default(vars.anarchy_subject.vars.__meta__.sandbox_api.resources)
+    vars.anarchy_governor.vars.job_vars.__meta__.sandboxes
     | default([])
     | length > 0
   }}
@@ -205,7 +202,6 @@ pool_manager_vault_password: "{{ aws_sandbox_manager.pool_manager_vault_password
 # Reservation
 sandbox_api_reservation: >-
   {{ vars.anarchy_governor.vars.job_vars.__meta__.sandbox_api.reservation
-  | default(vars.anarchy_subject.vars.__meta__.sandbox_api.reservation)
   | default("") }}
 
 # Control wether the Sandbox API is enough to cleanup everything. By default, it's true.
@@ -213,7 +209,6 @@ sandbox_api_reservation: >-
 # If the Controller job must succeed for a service to be considered delete, turn this to false in agnosticv __meta__.sandbox_api.destroy_catch_all
 sandbox_api_destroy_catch_all: >-
   {{ vars.anarchy_governor.vars.job_vars.__meta__.sandbox_api.destroy_catch_all
-  | default(vars.anarchy_subject.vars.__meta__.sandbox_api.destroy_catch_all)
   | default(true) }}
 
 sandbox_api_resources_default:
@@ -222,6 +217,5 @@ sandbox_api_resources_default:
 
 # Kind of resources to book
 sandbox_api_resources: >-
-  {{ vars.anarchy_governor.vars.job_vars.__meta__.sandbox_api.resources
-  | default(vars.anarchy_subject.vars.__meta__.sandbox_api.resources)
+  {{ vars.anarchy_governor.vars.job_vars.__meta__.sandboxes
   | default(sandbox_api_resources_default) }}

--- a/tasks/aws_sandbox_cleanup.yml
+++ b/tasks/aws_sandbox_cleanup.yml
@@ -34,5 +34,7 @@
 # If sandbox-api tasks didn't run or if placement was not found, it's safe to run legacy code to mark for cleanup any account matching uuid.
 # TODO: remove later
 # (when everything is using the sandbox-api and all services have a Placement in DB)
-- when: r_del.status | default(404) == 404
+- when:
+    - r_del.status | default(404) == 404
+    - pool_manager_aws_access_key_id | default('', true) != ''
   include_tasks: aws_sandbox_cleanup_legacy.yaml

--- a/tasks/aws_sandbox_cleanup_legacy.yaml
+++ b/tasks/aws_sandbox_cleanup_legacy.yaml
@@ -18,9 +18,9 @@
             S: "{{ vars.anarchy_subject.vars.job_vars.uuid }}"
       command: >-
         aws
-        --region "{{ aws_sandbox_manager.pool_region | default('us-east-1') }}"
+        --region "{{ dynamodb_pool_region }}"
         dynamodb scan
-        --table-name {{ aws_sandbox_manager.pool_table | default('accounts') }}
+        --table-name {{ dynamodb_pool_table }}
         --filter-expression '{{ _expression }}'
         --expression-attribute-values '{{ _data | to_json }}'
         --max-item 1
@@ -57,9 +57,9 @@
                 S: "{{ vars.anarchy_subject.vars.job_vars.uuid }}"
           command: >-
             aws
-            --region "{{ aws_sandbox_manager.pool_region | default('us-east-1') }}"
+            --region "{{ dynamodb_pool_region }}"
             dynamodb update-item
-            --table-name {{ aws_sandbox_manager.pool_table | default('accounts') }}
+            --table-name {{ dynamodb_pool_table }}
             --key "{\"name\": {\"S\": \"{{ sandbox_name }}\"}}"
             --update-expression "SET to_cleanup = :cl"
             --condition-expression "available = :av

--- a/tasks/handle-action-destroy-complete.yaml
+++ b/tasks/handle-action-destroy-complete.yaml
@@ -1,5 +1,5 @@
 ---
-- when: vars.anarchy_governor.vars.job_vars.__meta__.aws_sandboxed | default(false)
+- when: sandbox_api_in_use
   include_tasks: aws_sandbox_cleanup.yml
 
 - name: Set state destroy for {{ anarchy_subject_name }}

--- a/tasks/handle-action-destroy.yaml
+++ b/tasks/handle-action-destroy.yaml
@@ -1,4 +1,30 @@
 ---
+- when: >-
+    sandbox_api_in_use
+    and sandbox_api_destroy_catch_all
+    and (
+        'destroy-error' == current_state | default('') or
+        'destroy-failed' == current_state | default('') or
+        'destroy-canceled' == current_state | default('')
+    )
+
+  block:
+  - debug:
+      msg: >-
+        {{ current_state }}, Use sandbox API to cleanup {{ anarchy_subject_name }}
+        and delete + remove finalizers
+
+  - include_tasks: aws_sandbox_cleanup.yml
+
+  # The following proceed with the deletion of the anarchy subject if the Placement
+  # is deleted, even if the tower job failed.
+  - name: Complete deletion anarchy subject on destroy failure
+    anarchy_subject_delete:
+      remove_finalizers: true
+
+  # Do not run deployer destroy in this case, just use the Sandbox API to cleanup
+  - meta: end_play
+
 - name: Destroying {{ anarchy_subject_name }}
   when: current_state != "destroying"
   include_tasks: run-destroy.yaml

--- a/tasks/handle-event-delete-without-destroy.yaml
+++ b/tasks/handle-event-delete-without-destroy.yaml
@@ -1,4 +1,10 @@
 ---
+# When destroy is disable and if it's a sandbox + destroy_catch_all is true,
+# then delete placement from the sandbox API
+- when: >-
+    sandbox_api_in_use and sandbox_api_destroy_catch_all
+  include_tasks: aws_sandbox_cleanup.yml
+
 - name: Update state to destroyed for {{ anarchy_subject_name }} with no destroy action
   anarchy_subject_update:
     spec:

--- a/tasks/run-destroy.yaml
+++ b/tasks/run-destroy.yaml
@@ -1,4 +1,8 @@
 ---
+# Get sandbox to get the credential and perform deployer job
+- when: sandbox_api_in_use
+  include_tasks: sandbox_get.yaml
+
 - name: Set Ansible controller access facts
   vars:
     job_info: >-

--- a/tasks/run-provision.yaml
+++ b/tasks/run-provision.yaml
@@ -1,4 +1,8 @@
 ---
+# Get sandbox to get the credential and perform deployer job
+- when: sandbox_api_in_use
+  include_tasks: sandbox_get.yaml
+
 - name: Run deployer provision {{ anarchy_subject_name }}
   vars:
     new_subject_state: provisioning

--- a/tasks/run-start.yaml
+++ b/tasks/run-start.yaml
@@ -1,4 +1,8 @@
 ---
+# Get sandbox to get the credential and perform deployer job
+- when: sandbox_api_in_use
+  include_tasks: sandbox_get.yaml
+
 - name: Run deployer start {{ anarchy_subject_name }}
   vars:
     new_subject_state: starting

--- a/tasks/run-status.yaml
+++ b/tasks/run-status.yaml
@@ -1,4 +1,8 @@
 ---
+# Get sandbox to get the credential and perform deployer job
+- when: sandbox_api_in_use
+  include_tasks: sandbox_get.yaml
+
 - name: Run deployer status {{ anarchy_subject_name }}
   vars:
     new_check_status_state: running

--- a/tasks/run-stop.yaml
+++ b/tasks/run-stop.yaml
@@ -1,4 +1,8 @@
 ---
+# Get sandbox to get the credential and perform deployer job
+- when: sandbox_api_in_use
+  include_tasks: sandbox_get.yaml
+
 - name: Run deployer stop {{ anarchy_subject_name }}
   vars:
     new_subject_state: stopping

--- a/tasks/run-update.yaml
+++ b/tasks/run-update.yaml
@@ -1,4 +1,8 @@
 ---
+# Get sandbox to get the credential and perform deployer job
+- when: sandbox_api_in_use
+  include_tasks: sandbox_get.yaml
+
 - name: Run deployer update {{ anarchy_subject_name }}
   vars:
     new_subject_state: updating

--- a/tasks/sandbox_api_book.yaml
+++ b/tasks/sandbox_api_book.yaml
@@ -13,7 +13,7 @@
     ocp_console_url: >-
       {{ r_ocp_console_public.resources[0].data.consoleURL | default('') }}
 
-- name: Get a placement, book 1 aws sandbox
+- name: Get a placement, book sandbox(es)
   uri:
     headers:
       Authorization: Bearer {{ access_token }}

--- a/tasks/sandbox_api_book.yaml
+++ b/tasks/sandbox_api_book.yaml
@@ -1,0 +1,64 @@
+---
+- name: Get the cluster console
+  k8s_info:
+    api_version: v1
+    kind: ConfigMap
+    namespace: openshift-config-managed
+    name: console-public
+  register: r_ocp_console_public
+  changed_when: false
+
+- name: Set ocp_console_url
+  set_fact:
+    ocp_console_url: >-
+      {{ r_ocp_console_public.resources[0].data.consoleURL | default('') }}
+
+- name: Get a placement, book 1 aws sandbox
+  uri:
+    headers:
+      Authorization: Bearer {{ access_token }}
+    url: "{{ sandbox_api_url }}/api/v1/placements"
+    method: POST
+    body_format: json
+    body:
+      service_uuid: "{{ uuid }}"
+      reservation: "{{ sandbox_api_reservation }}"
+      annotations:
+        guid: "{{ guid }}"
+        env_type: "{{ env_type }}"
+        owner: "{{ requester_user }}"
+        owner_email: "{{ requester_email | default('unknown', True) }}"
+        comment: "sandbox-api {{ ocp_console_url }}"
+      resources: "{{ sandbox_api_resources }}"
+  register: r_new_placement
+  retries: "{{ sandbox_api_retries }}"
+  delay: "{{ sandbox_api_delay }}"
+  until: r_new_placement is succeeded
+  changed_when: true
+
+- name: Save placement
+  set_fact:
+    placement: "{{ r_new_placement.json.Placement }}"
+
+# TODO: capturing the result should be done depending on the resources requested.
+#       if it's Azure, then ... if count is 2, then ...
+#       That should probably be a module
+- set_fact:
+    sandbox_name: "{{ placement.resources[0].name }}"
+    sandbox_zone: "{{ placement.resources[0].zone }}"
+    sandbox_hosted_zone_id: "{{ placement.resources[0].hosted_zone_id }}"
+    sandbox_account: "{{ placement.resources[0].account_id }}"
+    sandbox_account_id: "{{ placement.resources[0].account_id }}"
+    sandbox_aws_access_key_id: >-
+      {{ (placement.resources[0].credentials
+      | selectattr('kind', 'equalto', 'aws_iam_key')
+      | selectattr('name', 'equalto', 'admin-key')
+      | first
+      ).get('aws_access_key_id') }}
+    sandbox_aws_secret_access_key: >-
+      {{ (placement.resources[0].credentials
+      | selectattr('kind', 'equalto', 'aws_iam_key')
+      | selectattr('name', 'equalto', 'admin-key')
+      | first).get('aws_secret_access_key') }}
+
+- include_tasks: set_aws_sandbox.yaml

--- a/tasks/sandbox_api_get.yaml
+++ b/tasks/sandbox_api_get.yaml
@@ -1,0 +1,42 @@
+---
+- name: Check if placement exists
+  uri:
+    headers:
+      Authorization: Bearer {{ access_token }}
+    url: "{{ sandbox_api_url }}/api/v1/placements/{{ uuid }}"
+    method: GET
+    status_code: [200, 404]
+  retries: "{{ sandbox_api_retries }}"
+  delay: "{{ sandbox_api_delay }}"
+  register: r_get_placement
+  until: r_get_placement is succeeded
+
+# Placement found
+- when: >-
+    r_get_placement.status == 200
+    and r_get_placement.json.resources | default([]) | length > 0
+  block:
+    - name: Set placement
+      set_fact:
+        placement: "{{ r_get_placement.json }}"
+
+    - name: Save sandbox variables
+      set_fact:
+        sandbox_name: "{{ placement.resources[0].name }}"
+        sandbox_zone: "{{ placement.resources[0].zone }}"
+        sandbox_hosted_zone_id: "{{ placement.resources[0].hosted_zone_id }}"
+        sandbox_account: "{{ placement.resources[0].account_id }}"
+        sandbox_account_id: "{{ placement.resources[0].account_id }}"
+        sandbox_aws_access_key_id: >-
+          {{ (placement.resources[0].credentials
+          | selectattr('kind', 'equalto', 'aws_iam_key')
+          | selectattr('name', 'equalto', 'admin-key')
+          | first
+          ).get('aws_access_key_id') }}
+        sandbox_aws_secret_access_key: >-
+          {{ (placement.resources[0].credentials
+          | selectattr('kind', 'equalto', 'aws_iam_key')
+          | selectattr('name', 'equalto', 'admin-key')
+          | first).get('aws_secret_access_key') }}
+
+    - include_tasks: set_aws_sandbox.yaml

--- a/tasks/sandbox_api_stop.yaml
+++ b/tasks/sandbox_api_stop.yaml
@@ -12,6 +12,7 @@
     retries: "{{ sandbox_api_retries }}"
     delay: "{{ sandbox_api_delay }}"
     until: r_stop is succeeded or r_stop.status == 404
+    changed_when: true
 
   - name: Set status in anarchy subject
     anarchy_subject_update:

--- a/tasks/sandbox_get.yaml
+++ b/tasks/sandbox_get.yaml
@@ -1,0 +1,13 @@
+---
+# First, try to get the information from the sandbox API using uuid and Placement
+- include_tasks: sandbox_api_login.yaml
+- include_tasks: sandbox_api_get.yaml
+
+# If no sandbox associated, book a new one using the Sandbox API
+# Run book only if the action is 'provision'
+- when: >-
+    anarchy_action_config_name == 'provision'
+    and r_get_placement.status | default(0, true) != 200
+    and sandbox_name is not defined
+    and sandbox_api_login_token | default("") != ""
+  include_tasks: sandbox_api_book.yaml

--- a/tasks/set_aws_sandbox.yaml
+++ b/tasks/set_aws_sandbox.yaml
@@ -1,0 +1,47 @@
+---
+- debug:
+    msg: >-
+      Sandbox {{ sandbox_name }} picked
+      uuid={{ uuid }}
+      guid={{ guid }}
+      env_type={{ env_type }}"
+
+- name: Save secret of aws_sandbox_secrets dictionary
+  set_fact:
+    aws_sandbox_secrets:
+      sandbox_aws_access_key_id: "{{ sandbox_aws_access_key_id }}"
+      sandbox_aws_secret_access_key: "{{ sandbox_aws_secret_access_key }}"
+      sandbox_hosted_zone_id: "{{ sandbox_hosted_zone_id }}"
+      sandbox_name: "{{ sandbox_name }}"
+      sandbox_account: "{{ sandbox_account }}"
+      sandbox_account_id: "{{ sandbox_account_id }}"
+      sandbox_zone: "{{ sandbox_zone }}"
+      # agnosticd
+      aws_access_key_id: "{{ sandbox_aws_access_key_id }}"
+      aws_secret_access_key: "{{ sandbox_aws_secret_access_key }}"
+      HostedZoneId: "{{ sandbox_hosted_zone_id }}"
+      subdomain_base_suffix: ".{{ sandbox_zone }}"
+
+- name: Inject secrets into dynamic_job_vars
+  set_fact:
+    dynamic_job_vars: >-
+      {{ vars.dynamic_job_vars
+      | default({})
+      | combine(aws_sandbox_secrets, recursive=True) }}
+
+- name: Set sandbox for {{ anarchy_subject_name }}
+  anarchy_subject_update:
+    skip_update_processing: true
+    metadata:
+      labels:
+        sandbox: "{{ sandbox_name }}"
+    spec:
+      vars:
+        job_vars:
+          sandbox_name: "{{ sandbox_name }}"
+          sandbox_account: "{{ sandbox_account }}"
+          sandbox_zone: "{{ sandbox_zone }}"
+          sandbox_hosted_zone_id: "{{ sandbox_hosted_zone_id }}"
+          # agnosticd
+          HostedZoneId: "{{ sandbox_hosted_zone_id }}"
+          subdomain_base_suffix: ".{{ sandbox_zone }}"


### PR DESCRIPTION
This commit, if applied, merges the role babylon_aws_sandbox [1].

Some new default variables are added to facilitate and make the ansible
code more readable.

- guid, uuid
- requester email and user
- `sandbox_api_in_use`: a boolean to know if the Sandbox API calls are required
  That introduces a new AgnosticV variable under `__meta__` to control
  what kinds of resources are needed for the catalog item.

  ```yaml
  __meta__:
    sandboxes:
        - kind: AwsSandbox
  ```

  That starts the work of being able to request different kinds of
  accounts from the configuration of the catalog items.

 - `sandbox_api_destroy_catch_all` boolean in AgnosticV configuration that
 allows the catalog item maintainer to decide whether the sandbox API
 should destroy the resources even if the Destroy deployer job failed.
 That can be useful in the future if we want to ensure the destroy job
 MUST be successful.

  ```yaml
  __meta__:
    sandbox_api:
      destroy_catch_all: true
  ```