### PR TITLE
Be able to run event-update when deployer disabled

### DIFF
--- a/defaults/main.yaml
+++ b/defaults/main.yaml
@@ -123,42 +123,36 @@ deployer_entry_points:
   destroy: >-
     {{ __meta__.deployer.actions.destroy.disable | default(false) | bool | ternary('',
      __meta__.deployer.actions.destroy.entry_point
-     | default(__meta__.deployer.entry_points.destroy)
      | default(__meta__.deployer.entry_point)
      | default('ansible/destroy.yml')
     )}}
   # Note, provision entry point cannot be disabled.
   provision: >-
     {{ __meta__.deployer.actions.provision.entry_point
-     | default(__meta__.deployer.entry_points.provision)
      | default(__meta__.deployer.entry_point)
      | default('ansible/main.yml')
     }}
   start: >-
     {{ __meta__.deployer.actions.start.disable | default(false) | bool | ternary('',
      __meta__.deployer.actions.start.entry_point
-     | default(__meta__.deployer.entry_points.start)
      | default(__meta__.deployer.entry_point)
      | default('ansible/lifecycle_entry_point.yml')
     )}}
   status: >-
     {{ __meta__.deployer.actions.status.disable | default(false) | bool | ternary('',
      __meta__.deployer.actions.status.entry_point
-     | default(__meta__.deployer.entry_points.status)
      | default(__meta__.deployer.entry_point)
      | default('ansible/lifecycle_entry_point.yml')
     )}}
   stop: >-
     {{ __meta__.deployer.actions.stop.disable | default(false) | bool | ternary('',
      __meta__.deployer.actions.stop.entry_point
-     | default(__meta__.deployer.entry_points.stop)
      | default(__meta__.deployer.entry_point)
      | default('ansible/lifecycle_entry_point.yml')
     )}}
   update: >-
     {{ __meta__.deployer.actions['update'].disable | default(false) | bool | ternary('',
      __meta__.deployer.actions['update'].entry_point
-     | default(__meta__.deployer.entry_points['update'])
      | default(__meta__.deployer.entry_point)
      | default('ansible/update.yml')
     )}}

--- a/tasks/handle-event-update.yaml
+++ b/tasks/handle-event-update.yaml
@@ -1,4 +1,26 @@
 ---
+- debug:
+    msg: |
+      _action = {{ _action }}
+      _current_state = {{ _current_state }}
+      _desired_state = {{ _desired_state }}
+      _current_job_vars = {{ _current_job_vars }}
+      _previous_job_vars = {{ _previous_job_vars }}
+      _action in vars.anarchy_governor.spec.actions = {{ _action in vars.anarchy_governor.spec.actions }}
+
+  vars:
+    _current_state: "{{ current_state | default('unknown') }}"
+    _desired_state: "{{ desired_state | default('unknown') }}"
+    _current_job_vars: "{{ vars.anarchy_subject.spec.vars.job_vars | default('unknown') }}"
+    _previous_job_vars: "{{ vars.anarchy_subject_previous_state.spec.vars.job_vars | default(_current_job_vars) }}"
+    _action: >-
+      {{
+        'update' if _current_job_vars != _previous_job_vars else
+        'start' if (_current_state == 'stopped' and _desired_state == 'started') else
+        'stop' if (_current_state == 'started' and _desired_state == 'stopped') else
+        'no action'
+      }}
+
 - name: Schedule action based on current_state and desired_state
   vars:
     _current_state: "{{ current_state | default('unknown') }}"

--- a/tasks/handle-event-update.yaml
+++ b/tasks/handle-event-update.yaml
@@ -1,26 +1,4 @@
 ---
-- debug:
-    msg: |
-      _action = {{ _action }}
-      _current_state = {{ _current_state }}
-      _desired_state = {{ _desired_state }}
-      _current_job_vars = {{ _current_job_vars }}
-      _previous_job_vars = {{ _previous_job_vars }}
-      _action in vars.anarchy_governor.spec.actions = {{ _action in vars.anarchy_governor.spec.actions }}
-
-  vars:
-    _current_state: "{{ current_state | default('unknown') }}"
-    _desired_state: "{{ desired_state | default('unknown') }}"
-    _current_job_vars: "{{ vars.anarchy_subject.spec.vars.job_vars | default('unknown') }}"
-    _previous_job_vars: "{{ vars.anarchy_subject_previous_state.spec.vars.job_vars | default(_current_job_vars) }}"
-    _action: >-
-      {{
-        'update' if _current_job_vars != _previous_job_vars else
-        'start' if (_current_state == 'stopped' and _desired_state == 'started') else
-        'stop' if (_current_state == 'started' and _desired_state == 'stopped') else
-        'no action'
-      }}
-
 - name: Schedule action based on current_state and desired_state
   vars:
     _current_state: "{{ current_state | default('unknown') }}"

--- a/tasks/handle-event-update.yaml
+++ b/tasks/handle-event-update.yaml
@@ -12,9 +12,7 @@
         'stop' if (_current_state == 'started' and _desired_state == 'stopped') else
         'no action'
       }}
-  when: >-
-    _action in vars.anarchy_governor.spec.actions and
-    deployer_entry_points[_action] | default('', true) != ''
+  when: _action in vars.anarchy_governor.spec.actions
   block:
   - name: Set {{ anarchy_subject_name }} current state to {{ _action }}-pending
     anarchy_subject_update:
@@ -44,8 +42,7 @@
       check_status_request_timestamp != last_check_status_request_timestamp and
       check_status_state in ['', 'successful']
     )) and
-    'status' in vars.anarchy_governor.spec.actions and
-    deployer_entry_points.status | default('', true) != ''
+    'status' in vars.anarchy_governor.spec.actions
   block:
   - name: Set {{ anarchy_subject_name }} check_status to false
     anarchy_subject_update:


### PR DESCRIPTION
Update the condition in handl-event-update to not require the deployer actions to be enabled.

That allows the sandbox API to run standalone