### PR TITLE
Don't print controller password but its hash

### DIFF
--- a/tasks/controller-access-facts.yaml
+++ b/tasks/controller-access-facts.yaml
@@ -26,8 +26,8 @@
       }}{% endif %}
 
 - debug:
-    msg: |
-      controller_host: {{ controller_host }}
-      controller_user: {{ controller_user }}
-      controller_password: {{ controller_password }}
+    msg:
+    - controller_host: {{ controller_host }}
+    - controller_user: {{ controller_user }}
+    - sha256(controller_password): {{ controller_password | hash('sha256') }}
 ...


### PR DESCRIPTION
Don't print the password to every log, just its sha256.

This way an admin could still ensure the password is correct

Use debug multiline.