### PR TITLE
Fix OpenShift var name conflicts in agnosticd

### DIFF
--- a/filter_plugins/babylon.py
+++ b/filter_plugins/babylon.py
@@ -243,17 +243,12 @@ def extract_sandboxes_vars(response, creds=True):
                 'sandbox_openshift_cluster': sandbox_openshift_cluster,
                 'sandbox_openshift_api_url': sandbox_openshift_api_url,
                 'sandbox_openshift_apps_domain': sandbox_openshift_apps_domain,
-                'openshift_cluster': sandbox_openshift_cluster,
-                'openshift_api_url': sandbox_openshift_api_url,
-                'openshift_apps_domain': sandbox_openshift_apps_domain,
-                'openshift_namespace': sandbox_openshift_namespace,
             }
 
             if creds:
                 for creds in sandbox.get('credentials', []):
                     if creds.get('kind', 'none') == 'ServiceAccount':
                         to_merge['sandbox_openshift_api_key'] = creds.get('token', 'unknown')
-                        to_merge['openshift_api_key'] = creds.get('token', 'unknown')
                         to_merge['sandbox_openshift_credentials'] = sandbox.get('credentials', [])
                         break
 


### PR DESCRIPTION
Some roles expect variables like `openshift_api_url` to come from the host-ocp4-installer.

This fix makes sure those variables are not overwritten by the sandbox API.