### PR TITLE
Ensure consistent status and timestamp for failed actions

### DIFF
--- a/tasks/handle-action-destroy-canceled.yaml
+++ b/tasks/handle-action-destroy-canceled.yaml
@@ -8,6 +8,12 @@
     spec:
       vars:
         current_state: destroy-canceled
+    status:
+      towerJobs:
+        destroy:
+          completeTimestamp: '{{ anarchy_run_timestamp }}'
+          jobStatus: canceled
+
 
 - name: Schedule destroy retry for {{ anarchy_subject_name }}
   anarchy_continue_action:

--- a/tasks/handle-action-destroy-error.yaml
+++ b/tasks/handle-action-destroy-error.yaml
@@ -8,6 +8,12 @@
     spec:
       vars:
         current_state: destroy-error
+    status:
+      towerJobs:
+        destroy:
+          completeTimestamp: '{{ anarchy_run_timestamp }}'
+          jobStatus: error
+
 
 - name: Schedule destroy retry for {{ anarchy_subject_name }}
   anarchy_continue_action:

--- a/tasks/handle-action-destroy-failed.yaml
+++ b/tasks/handle-action-destroy-failed.yaml
@@ -8,6 +8,12 @@
     spec:
       vars:
         current_state: destroy-failed
+    status:
+      towerJobs:
+        destroy:
+          completeTimestamp: '{{ anarchy_run_timestamp }}'
+          jobStatus: failed
+
 
 - name: Schedule destroy retry for {{ anarchy_subject_name }}
   anarchy_continue_action:

--- a/tasks/handle-action-provision-canceled.yaml
+++ b/tasks/handle-action-provision-canceled.yaml
@@ -19,6 +19,11 @@
       vars:
         current_state: provision-canceled
         healthy: false
+    status:
+      towerJobs:
+        provision:
+          completeTimestamp: '{{ anarchy_run_timestamp }}'
+          jobStatus: canceled
 
 - name: Finish action {{ anarchy_action_name }} as canceled
   anarchy_finish_action:

--- a/tasks/handle-action-provision-error.yaml
+++ b/tasks/handle-action-provision-error.yaml
@@ -19,6 +19,11 @@
       vars:
         current_state: provision-error
         healthy: false
+    status:
+      towerJobs:
+        provision:
+          completeTimestamp: '{{ anarchy_run_timestamp }}'
+          jobStatus: error
 
 - name: Finish action {{ anarchy_action_name }} as error
   anarchy_finish_action:

--- a/tasks/handle-action-provision-failed.yaml
+++ b/tasks/handle-action-provision-failed.yaml
@@ -19,6 +19,11 @@
       vars:
         current_state: provision-failed
         healthy: false
+    status:
+      towerJobs:
+        provision:
+          completeTimestamp: '{{ anarchy_run_timestamp }}'
+          jobStatus: failed
 
 - name: Finish action {{ anarchy_action_name }} as failed
   anarchy_finish_action:

--- a/tasks/handle-action-start-canceled.yaml
+++ b/tasks/handle-action-start-canceled.yaml
@@ -9,6 +9,11 @@
       vars:
         current_state: start-canceled
         healthy: false
+    status:
+      towerJobs:
+        start:
+          completeTimestamp: '{{ anarchy_run_timestamp }}'
+          jobStatus: canceled
 
 - name: Schedule start retry for {{ anarchy_subject_name }}
   when: desired_state == 'started' and vars.anarchy_subject.metadata.deletionTimestamp is not defined

--- a/tasks/handle-action-start-error.yaml
+++ b/tasks/handle-action-start-error.yaml
@@ -9,6 +9,11 @@
       vars:
         current_state: start-error
         healthy: false
+    status:
+      towerJobs:
+        start:
+          completeTimestamp: '{{ anarchy_run_timestamp }}'
+          jobStatus: error
 
 - name: Schedule start retry for {{ anarchy_subject_name }}
   when: desired_state == 'started' and vars.anarchy_subject.metadata.deletionTimestamp is not defined

--- a/tasks/handle-action-start-failed.yaml
+++ b/tasks/handle-action-start-failed.yaml
@@ -9,6 +9,11 @@
       vars:
         current_state: start-failed
         healthy: false
+    status:
+      towerJobs:
+        start:
+          completeTimestamp: '{{ anarchy_run_timestamp }}'
+          jobStatus: failed
 
 - name: Schedule start retry for {{ anarchy_subject_name }}
   when: desired_state == 'started' and vars.anarchy_subject.metadata.deletionTimestamp is not defined

--- a/tasks/handle-action-status-canceled.yaml
+++ b/tasks/handle-action-status-canceled.yaml
@@ -6,6 +6,11 @@
     spec:
       vars:
         check_status_state: canceled
+    status:
+      towerJobs:
+        status:
+          completeTimestamp: '{{ anarchy_run_timestamp }}'
+          jobStatus: canceled
 
 - name: Finish action {{ anarchy_action_name }} as canceled
   anarchy_finish_action:

--- a/tasks/handle-action-status-error.yaml
+++ b/tasks/handle-action-status-error.yaml
@@ -6,6 +6,11 @@
     spec:
       vars:
         check_status_state: error
+    status:
+      towerJobs:
+        status:
+          completeTimestamp: '{{ anarchy_run_timestamp }}'
+          jobStatus: error
 
 - name: Finish action {{ anarchy_action_name }} as error
   anarchy_finish_action:

--- a/tasks/handle-action-status-failed.yaml
+++ b/tasks/handle-action-status-failed.yaml
@@ -6,6 +6,11 @@
     spec:
       vars:
         check_status_state: failed
+    status:
+      towerJobs:
+        status:
+          completeTimestamp: '{{ anarchy_run_timestamp }}'
+          jobStatus: failed
 
 - name: Finish action {{ anarchy_action_name }} as failed
   anarchy_finish_action:

--- a/tasks/handle-action-stop-canceled.yaml
+++ b/tasks/handle-action-stop-canceled.yaml
@@ -9,6 +9,11 @@
       vars:
         current_state: stop-canceled
         healthy: false
+    status:
+      towerJobs:
+        stop:
+          completeTimestamp: '{{ anarchy_run_timestamp }}'
+          jobStatus: canceled
 
 - name: Schedule stop retry for {{ anarchy_subject_name }}
   when: desired_state == 'stopped' and vars.anarchy_subject.metadata.deletionTimestamp is not defined

--- a/tasks/handle-action-stop-error.yaml
+++ b/tasks/handle-action-stop-error.yaml
@@ -21,6 +21,11 @@
       vars:
         current_state: stop-error
         healthy: false
+    status:
+      towerJobs:
+        stop:
+          completeTimestamp: '{{ anarchy_run_timestamp }}'
+          jobStatus: error
 
 - name: Schedule stop retry for {{ anarchy_subject_name }}
   when: desired_state == 'stopped' and vars.anarchy_subject.metadata.deletionTimestamp is not defined

--- a/tasks/handle-action-stop-failed.yaml
+++ b/tasks/handle-action-stop-failed.yaml
@@ -21,6 +21,11 @@
       vars:
         current_state: stop-failed
         healthy: false
+    status:
+      towerJobs:
+        stop:
+          completeTimestamp: '{{ anarchy_run_timestamp }}'
+          jobStatus: failed
 
 - name: Schedule stop retry for {{ anarchy_subject_name }}
   when: desired_state == 'stopped' and vars.anarchy_subject.metadata.deletionTimestamp is not defined

--- a/tasks/handle-action-update-canceled.yaml
+++ b/tasks/handle-action-update-canceled.yaml
@@ -9,6 +9,11 @@
       vars:
         current_state: update-canceled
         healthy: false
+    status:
+      towerJobs:
+        update:
+          completeTimestamp: '{{ anarchy_run_timestamp }}'
+          jobStatus: canceled
 
 - name: Schedule update retry for {{ anarchy_subject_name }}
   when: vars.anarchy_subject.metadata.deletionTimestamp is not defined

--- a/tasks/handle-action-update-error.yaml
+++ b/tasks/handle-action-update-error.yaml
@@ -9,6 +9,11 @@
       vars:
         current_state: update-error
         healthy: false
+    status:
+      towerJobs:
+        update:
+          completeTimestamp: '{{ anarchy_run_timestamp }}'
+          jobStatus: error
 
 - name: Schedule update retry for {{ anarchy_subject_name }}
   when: vars.anarchy_subject.metadata.deletionTimestamp is not defined

--- a/tasks/handle-action-update-failed.yaml
+++ b/tasks/handle-action-update-failed.yaml
@@ -9,6 +9,11 @@
       vars:
         current_state: update-failed
         healthy: false
+    status:
+      towerJobs:
+        update:
+          completeTimestamp: '{{ anarchy_run_timestamp }}'
+          jobStatus: failed
 
 - name: Schedule update retry for {{ anarchy_subject_name }}
   when: vars.anarchy_subject.metadata.deletionTimestamp is not defined


### PR DESCRIPTION
- Update the `towerJobs` status for failed actions including `destroy`, `provision`, `start`, `stop`, and `update`.
- Add `completeTimestamp` and `jobStatus` to ensure consistent recording of action time and status,
  aligning with the existing handling for completed actions.