### PR TITLE
feat: Add new variables to job_vars

### DIFF
--- a/tasks/handle-event-create.yaml
+++ b/tasks/handle-event-create.yaml
@@ -13,11 +13,9 @@
           cloud_provider: >-
             {{ vars.anarchy_governor.spec.vars.job_vars.cloud_provider | default('none') }}
           platform: >-
-            {{ vars.anarchy_governor.spec.vars.job_vars.datasource | default('RHPDS') }}
+            {{ vars.anarchy_governor.spec.vars.job_vars.datasource | default('rhpds') }}
           uuid: >-
             {{ vars.anarchy_subject.spec.vars.job_vars.uuid | default((2**127) | random | to_uuid) }}
-          workload_shared_deployment: >-
-            {{ vars.anarchy_governor.spec.vars.job_vars.shared_deployment | default('false') }}
 
 - name: Schedule provision for {{ anarchy_subject_name }}
   anarchy_schedule_action:

--- a/tasks/handle-event-create.yaml
+++ b/tasks/handle-event-create.yaml
@@ -10,8 +10,14 @@
       vars:
         current_state: provision-pending
         job_vars:
+          cloud_provider: >-
+            {{ vars.anarchy_governor.spec.vars.job_vars.cloud_provider | default('none') }}
+          platform: >-
+            {{ vars.anarchy_governor.spec.vars.job_vars.datasource | default('RHPDS') }}
           uuid: >-
             {{ vars.anarchy_subject.spec.vars.job_vars.uuid | default((2**127) | random | to_uuid) }}
+          workload_shared_deployment: >-
+            {{ vars.anarchy_governor.spec.vars.job_vars.shared_deployment | default('false') }}
 
 - name: Schedule provision for {{ anarchy_subject_name }}
   anarchy_schedule_action:


### PR DESCRIPTION
- Added new variables workload_shared_deployment, platform, and cloud_provider to job_vars in handle-event-create.yaml.
- Default values set for shared_deployment, platform as 'RHPDS', and cloud_provider as 'none'.