### PR TITLE
Merge sandbox API additional vars

### DIFF
--- a/filter_plugins/babylon.py
+++ b/filter_plugins/babylon.py
@@ -252,6 +252,12 @@ def extract_sandboxes_vars(response, creds=True):
                         to_merge['sandbox_openshift_credentials'] = sandbox.get('credentials', [])
                         break
 
+            sandbox_additional_vars = sandbox.get('additional_vars', {}).get('deployer', {})
+
+            # Additional vars set in the OcpSharedClusterConfiguration
+            # are merged with the sandbox vars
+            for key, value in sandbox_additional_vars.items():
+                to_merge[key] = value
 
             var = sandbox.get('annotations', {}).get('var', 'main')
             if var == 'main':


### PR DESCRIPTION
Depending on the cluster scheduled, we can have the need for custom defined vars.
That is implemented in the sandbox API as "additional vars" in the OcpSharedClusterConfiguration.

This change adds the vars back to the vars passed to the deployer