### PR TITLE
[WIP] Update sandbox_api_get.yaml to wait for success status

### DIFF
--- a/tasks/sandbox_api_get.yaml
+++ b/tasks/sandbox_api_get.yaml
@@ -11,6 +11,19 @@
   register: r_get_placement
   until: r_get_placement.json.status | default('unknown') in ['success', 'error']
 
+- name: Finish action {{ anarchy_action_name }} as failed
+  when: r_get_placement.json.status == 'error'
+  block:
+  - name: Debug placement error
+    debug:
+      var: r_get_placement
+      
+  - name: Finish action {{ anarchy_action_name }} as failed
+    include_tasks:
+      file: handle-action-{{ anarchy_action_config_name }}-error.yaml
+
+  - meta: end_play
+
 # Placement found
 - when: >-
     r_get_placement.status == 200

--- a/tasks/sandbox_api_get.yaml
+++ b/tasks/sandbox_api_get.yaml
@@ -9,7 +9,7 @@
   retries: "{{ sandbox_api_retries }}"
   delay: "{{ sandbox_api_delay }}"
   register: r_get_placement
-  until: r_get_placement is succeeded and r_get_placement.json.status|default("") == "success"
+  until: r_get_placement.json.status | default('unknown') in ['success', 'error']
 
 # Placement found
 - when: >-

--- a/tasks/sandbox_api_get.yaml
+++ b/tasks/sandbox_api_get.yaml
@@ -9,7 +9,7 @@
   retries: "{{ sandbox_api_retries }}"
   delay: "{{ sandbox_api_delay }}"
   register: r_get_placement
-  until: r_get_placement is succeeded
+  until: r_get_placement is succeeded and r_get_placement.json.status|default("") == "success"
 
 # Placement found
 - when: >-


### PR DESCRIPTION
If the SA creation takes long, we return some variables but not the SA token
here we wait till the placement has success status