### PR TITLE
Allow deployer to be disabled for provision and destroy

### DIFF
--- a/defaults/main.yaml
+++ b/defaults/main.yaml
@@ -194,7 +194,7 @@ sandbox_api_url: >-
 sandbox_api_retries: 40
 sandbox_api_delay: 5
 
-now_time_utc: "{{ now(utc=true, fmt='%Y-%m-%dT%H:%M:%S') }}"
+now_time_utc: "{{ now(utc=true, fmt='%FT%TZ') }}"
 
 # Variables from secret via the aws_sandbox_manager variable
 dynamodb_pool_table: "{{ aws_sandbox_manager.pool_table | default('accounts') }}"

--- a/defaults/main.yaml
+++ b/defaults/main.yaml
@@ -191,8 +191,8 @@ sandbox_api_login_token: "{{ sandbox_api.sandbox_api_login_token }}"
 sandbox_api_url: >-
   {{ sandbox_api.sandbox_api_url
   | default('http://sandbox-api.babylon-sandbox-api.svc.cluster.local:8080') }}
-sandbox_api_retries: 10
-sandbox_api_delay: 30
+sandbox_api_retries: 40
+sandbox_api_delay: 5
 
 now_time_utc: "{{ now(utc=true, fmt='%Y-%m-%dT%H:%M:%S') }}"
 

--- a/tasks/handle-action-destroy-canceled.yaml
+++ b/tasks/handle-action-destroy-canceled.yaml
@@ -9,6 +9,10 @@
       vars:
         current_state: destroy-canceled
     status:
+      actions:
+        destroy:
+          completeTimestamp: '{{ anarchy_run_timestamp }}'
+          state: canceled
       towerJobs:
         destroy:
           completeTimestamp: '{{ anarchy_run_timestamp }}'

--- a/tasks/handle-action-destroy-canceled.yaml
+++ b/tasks/handle-action-destroy-canceled.yaml
@@ -11,11 +11,11 @@
     status:
       actions:
         destroy:
-          completeTimestamp: '{{ anarchy_run_timestamp }}'
+          completeTimestamp: '{{ now_time_utc }}'
           state: canceled
       towerJobs:
         destroy:
-          completeTimestamp: '{{ anarchy_run_timestamp }}'
+          completeTimestamp: '{{ now_time_utc }}'
           jobStatus: canceled
 
 - name: Schedule destroy retry for {{ anarchy_subject_name }}

--- a/tasks/handle-action-destroy-complete.yaml
+++ b/tasks/handle-action-destroy-complete.yaml
@@ -14,11 +14,11 @@
     status:
       actions:
         destroy:
-          completeTimestamp: '{{ anarchy_run_timestamp }}'
+          completeTimestamp: '{{ now_time_utc }}'
           state: successful
       towerJobs:
         destroy:
-          completeTimestamp: '{{ anarchy_run_timestamp }}'
+          completeTimestamp: '{{ now_time_utc }}'
           jobStatus: successful
 
 - name: Complete AnarchySubject deletion

--- a/tasks/handle-action-destroy-complete.yaml
+++ b/tasks/handle-action-destroy-complete.yaml
@@ -12,6 +12,10 @@
       vars:
         current_state: destroy-complete
     status:
+      actions:
+        destroy:
+          completeTimestamp: '{{ anarchy_run_timestamp }}'
+          state: successful
       towerJobs:
         destroy:
           completeTimestamp: '{{ anarchy_run_timestamp }}'

--- a/tasks/handle-action-destroy-error.yaml
+++ b/tasks/handle-action-destroy-error.yaml
@@ -11,11 +11,11 @@
     status:
       actions:
         destroy:
-          completeTimestamp: '{{ anarchy_run_timestamp }}'
+          completeTimestamp: '{{ now_time_utc }}'
           state: error
       towerJobs:
         destroy:
-          completeTimestamp: '{{ anarchy_run_timestamp }}'
+          completeTimestamp: '{{ now_time_utc }}'
           jobStatus: error
 
 - name: Schedule destroy retry for {{ anarchy_subject_name }}

--- a/tasks/handle-action-destroy-error.yaml
+++ b/tasks/handle-action-destroy-error.yaml
@@ -9,6 +9,10 @@
       vars:
         current_state: destroy-error
     status:
+      actions:
+        destroy:
+          completeTimestamp: '{{ anarchy_run_timestamp }}'
+          state: error
       towerJobs:
         destroy:
           completeTimestamp: '{{ anarchy_run_timestamp }}'

--- a/tasks/handle-action-destroy-failed.yaml
+++ b/tasks/handle-action-destroy-failed.yaml
@@ -11,11 +11,11 @@
     status:
       actions:
         destroy:
-          completeTimestamp: '{{ anarchy_run_timestamp }}'
+          completeTimestamp: '{{ now_time_utc }}'
           state: failed
       towerJobs:
         destroy:
-          completeTimestamp: '{{ anarchy_run_timestamp }}'
+          completeTimestamp: '{{ now_time_utc }}'
           jobStatus: failed
 
 - name: Schedule destroy retry for {{ anarchy_subject_name }}

--- a/tasks/handle-action-destroy-failed.yaml
+++ b/tasks/handle-action-destroy-failed.yaml
@@ -9,6 +9,10 @@
       vars:
         current_state: destroy-failed
     status:
+      actions:
+        destroy:
+          completeTimestamp: '{{ anarchy_run_timestamp }}'
+          state: failed
       towerJobs:
         destroy:
           completeTimestamp: '{{ anarchy_run_timestamp }}'

--- a/tasks/handle-action-destroy.yaml
+++ b/tasks/handle-action-destroy.yaml
@@ -5,7 +5,8 @@
     and (
         'destroy-error' == current_state | default('') or
         'destroy-failed' == current_state | default('') or
-        'destroy-canceled' == current_state | default('')
+        'destroy-canceled' == current_state | default('') or
+        __meta__.deployer.actions.destroy.disable | default(false) | bool
     )
 
   block:
@@ -26,11 +27,17 @@
   - meta: end_play
 
 - name: Destroying {{ anarchy_subject_name }}
-  when: current_state != "destroying"
+  when: >-
+    current_state != "destroying"
+    and
+    not __meta__.deployer.actions.destroy.disable | default(false) | bool
   include_tasks: run-destroy.yaml
 
 - name: Check destroy of {{ anarchy_subject_name }}
-  when: current_state == "destroying"
+  when: >-
+    current_state == "destroying"
+    and
+    not __meta__.deployer.actions.destroy.disable | default(false) | bool
   vars:
     job_action: destroy
     job_info: "{{ vars.anarchy_subject.status.towerJobs.destroy }}"

--- a/tasks/handle-action-provision-canceled.yaml
+++ b/tasks/handle-action-provision-canceled.yaml
@@ -22,11 +22,11 @@
     status:
       actions:
         provision:
-          completeTimestamp: '{{ anarchy_run_timestamp }}'
+          completeTimestamp: '{{ now_time_utc }}'
           state: canceled
       towerJobs:
         provision:
-          completeTimestamp: '{{ anarchy_run_timestamp }}'
+          completeTimestamp: '{{ now_time_utc }}'
           jobStatus: canceled
 
 - name: Finish action {{ anarchy_action_name }} as canceled

--- a/tasks/handle-action-provision-canceled.yaml
+++ b/tasks/handle-action-provision-canceled.yaml
@@ -20,6 +20,10 @@
         current_state: provision-canceled
         healthy: false
     status:
+      actions:
+        provision:
+          completeTimestamp: '{{ anarchy_run_timestamp }}'
+          state: canceled
       towerJobs:
         provision:
           completeTimestamp: '{{ anarchy_run_timestamp }}'

--- a/tasks/handle-action-provision-complete.yaml
+++ b/tasks/handle-action-provision-complete.yaml
@@ -14,11 +14,11 @@
     status:
       actions:
         provision:
-          completeTimestamp: '{{ anarchy_run_timestamp }}'
+          completeTimestamp: '{{ now_time_utc }}'
           state: successful
       towerJobs:
         provision:
-          completeTimestamp: '{{ anarchy_run_timestamp }}'
+          completeTimestamp: '{{ now_time_utc }}'
           jobStatus: successful
 
 - name: Report action successful

--- a/tasks/handle-action-provision-complete.yaml
+++ b/tasks/handle-action-provision-complete.yaml
@@ -12,6 +12,10 @@
         provision_message_body: '{{ action_provision_message_body | default(omit, true) }}'
         provision_messages: '{{ action_provision_messages | default(omit, true) }}'
     status:
+      actions:
+        provision:
+          completeTimestamp: '{{ anarchy_run_timestamp }}'
+          state: successful
       towerJobs:
         provision:
           completeTimestamp: '{{ anarchy_run_timestamp }}'

--- a/tasks/handle-action-provision-error.yaml
+++ b/tasks/handle-action-provision-error.yaml
@@ -20,6 +20,10 @@
         current_state: provision-error
         healthy: false
     status:
+      actions:
+        provision:
+          completeTimestamp: '{{ anarchy_run_timestamp }}'
+          state: error
       towerJobs:
         provision:
           completeTimestamp: '{{ anarchy_run_timestamp }}'

--- a/tasks/handle-action-provision-error.yaml
+++ b/tasks/handle-action-provision-error.yaml
@@ -22,11 +22,11 @@
     status:
       actions:
         provision:
-          completeTimestamp: '{{ anarchy_run_timestamp }}'
+          completeTimestamp: '{{ now_time_utc }}'
           state: error
       towerJobs:
         provision:
-          completeTimestamp: '{{ anarchy_run_timestamp }}'
+          completeTimestamp: '{{ now_time_utc }}'
           jobStatus: error
 
 - name: Finish action {{ anarchy_action_name }} as error

--- a/tasks/handle-action-provision-failed.yaml
+++ b/tasks/handle-action-provision-failed.yaml
@@ -22,11 +22,11 @@
     status:
       actions:
         provision:
-          completeTimestamp: '{{ anarchy_run_timestamp }}'
+          completeTimestamp: '{{ now_time_utc }}'
           state: failed
       towerJobs:
         provision:
-          completeTimestamp: '{{ anarchy_run_timestamp }}'
+          completeTimestamp: '{{ now_time_utc }}'
           jobStatus: failed
 
 - name: Finish action {{ anarchy_action_name }} as failed

--- a/tasks/handle-action-provision-failed.yaml
+++ b/tasks/handle-action-provision-failed.yaml
@@ -20,6 +20,10 @@
         current_state: provision-failed
         healthy: false
     status:
+      actions:
+        provision:
+          completeTimestamp: '{{ anarchy_run_timestamp }}'
+          state: failed
       towerJobs:
         provision:
           completeTimestamp: '{{ anarchy_run_timestamp }}'

--- a/tasks/handle-action-provision.yaml
+++ b/tasks/handle-action-provision.yaml
@@ -1,10 +1,14 @@
 ---
 - name: Provision {{ anarchy_subject_name }}
-  when: current_state == "provision-pending"
+  when: >-
+    current_state == "provision-pending"
   include_tasks: run-provision.yaml
 
 - name: Check provision of {{ anarchy_subject_name }}
-  when: current_state == "provisioning"
+  when: >-
+    current_state == "provisioning"
+    and
+    not __meta__.deployer.actions.provision.disable | default(false) | bool
   vars:
     job_action: provision
     job_info: "{{ vars.anarchy_subject.status.towerJobs.provision }}"

--- a/tasks/handle-action-start-canceled.yaml
+++ b/tasks/handle-action-start-canceled.yaml
@@ -10,6 +10,10 @@
         current_state: start-canceled
         healthy: false
     status:
+      actions:
+        start:
+          completeTimestamp: '{{ anarchy_run_timestamp }}'
+          state: canceled
       towerJobs:
         start:
           completeTimestamp: '{{ anarchy_run_timestamp }}'

--- a/tasks/handle-action-start-canceled.yaml
+++ b/tasks/handle-action-start-canceled.yaml
@@ -12,11 +12,11 @@
     status:
       actions:
         start:
-          completeTimestamp: '{{ anarchy_run_timestamp }}'
+          completeTimestamp: '{{ now_time_utc }}'
           state: canceled
       towerJobs:
         start:
-          completeTimestamp: '{{ anarchy_run_timestamp }}'
+          completeTimestamp: '{{ now_time_utc }}'
           jobStatus: canceled
 
 - name: Schedule start retry for {{ anarchy_subject_name }}

--- a/tasks/handle-action-start-complete.yaml
+++ b/tasks/handle-action-start-complete.yaml
@@ -10,11 +10,11 @@
     status:
       actions:
         start:
-          completeTimestamp: '{{ anarchy_run_timestamp }}'
+          completeTimestamp: '{{ now_time_utc }}'
           state: successful
       towerJobs:
         start:
-          completeTimestamp: '{{ anarchy_run_timestamp }}'
+          completeTimestamp: '{{ now_time_utc }}'
           jobStatus: successful
 
 - name: Report action successful

--- a/tasks/handle-action-start-complete.yaml
+++ b/tasks/handle-action-start-complete.yaml
@@ -8,6 +8,10 @@
       vars:
         current_state: started
     status:
+      actions:
+        start:
+          completeTimestamp: '{{ anarchy_run_timestamp }}'
+          state: successful
       towerJobs:
         start:
           completeTimestamp: '{{ anarchy_run_timestamp }}'

--- a/tasks/handle-action-start-error.yaml
+++ b/tasks/handle-action-start-error.yaml
@@ -10,6 +10,10 @@
         current_state: start-error
         healthy: false
     status:
+      actions:
+        start:
+          completeTimestamp: '{{ anarchy_run_timestamp }}'
+          state: error
       towerJobs:
         start:
           completeTimestamp: '{{ anarchy_run_timestamp }}'

--- a/tasks/handle-action-start-error.yaml
+++ b/tasks/handle-action-start-error.yaml
@@ -12,11 +12,11 @@
     status:
       actions:
         start:
-          completeTimestamp: '{{ anarchy_run_timestamp }}'
+          completeTimestamp: '{{ now_time_utc }}'
           state: error
       towerJobs:
         start:
-          completeTimestamp: '{{ anarchy_run_timestamp }}'
+          completeTimestamp: '{{ now_time_utc }}'
           jobStatus: error
 
 - name: Schedule start retry for {{ anarchy_subject_name }}

--- a/tasks/handle-action-start-failed.yaml
+++ b/tasks/handle-action-start-failed.yaml
@@ -10,6 +10,10 @@
         current_state: start-failed
         healthy: false
     status:
+      actions:
+        start:
+          completeTimestamp: '{{ anarchy_run_timestamp }}'
+          state: failed
       towerJobs:
         start:
           completeTimestamp: '{{ anarchy_run_timestamp }}'

--- a/tasks/handle-action-start-failed.yaml
+++ b/tasks/handle-action-start-failed.yaml
@@ -12,11 +12,11 @@
     status:
       actions:
         start:
-          completeTimestamp: '{{ anarchy_run_timestamp }}'
+          completeTimestamp: '{{ now_time_utc }}'
           state: failed
       towerJobs:
         start:
-          completeTimestamp: '{{ anarchy_run_timestamp }}'
+          completeTimestamp: '{{ now_time_utc }}'
           jobStatus: failed
 
 - name: Schedule start retry for {{ anarchy_subject_name }}

--- a/tasks/handle-action-status-canceled.yaml
+++ b/tasks/handle-action-status-canceled.yaml
@@ -7,6 +7,10 @@
       vars:
         check_status_state: canceled
     status:
+      actions:
+        status:
+          completeTimestamp: '{{ anarchy_run_timestamp }}'
+          state: canceled
       towerJobs:
         status:
           completeTimestamp: '{{ anarchy_run_timestamp }}'

--- a/tasks/handle-action-status-canceled.yaml
+++ b/tasks/handle-action-status-canceled.yaml
@@ -9,11 +9,11 @@
     status:
       actions:
         status:
-          completeTimestamp: '{{ anarchy_run_timestamp }}'
+          completeTimestamp: '{{ now_time_utc }}'
           state: canceled
       towerJobs:
         status:
-          completeTimestamp: '{{ anarchy_run_timestamp }}'
+          completeTimestamp: '{{ now_time_utc }}'
           jobStatus: canceled
 
 - name: Finish action {{ anarchy_action_name }} as canceled

--- a/tasks/handle-action-status-complete.yaml
+++ b/tasks/handle-action-status-complete.yaml
@@ -9,11 +9,11 @@
     status:
       actions:
         status:
-          completeTimestamp: '{{ anarchy_run_timestamp }}'
+          completeTimestamp: '{{ now_time_utc }}'
           state: successful
       towerJobs:
         status:
-          completeTimestamp: '{{ anarchy_run_timestamp }}'
+          completeTimestamp: '{{ now_time_utc }}'
           jobStatus: successful
 
 - name: Report action successful

--- a/tasks/handle-action-status-complete.yaml
+++ b/tasks/handle-action-status-complete.yaml
@@ -7,6 +7,10 @@
         status_data: '{{ action_provision_data | default(omit, true) }}'
         status_messages: '{{ action_provision_messages | default(omit, true) }}'
     status:
+      actions:
+        status:
+          completeTimestamp: '{{ anarchy_run_timestamp }}'
+          state: successful
       towerJobs:
         status:
           completeTimestamp: '{{ anarchy_run_timestamp }}'

--- a/tasks/handle-action-status-error.yaml
+++ b/tasks/handle-action-status-error.yaml
@@ -9,11 +9,11 @@
     status:
       actions:
         status:
-          completeTimestamp: '{{ anarchy_run_timestamp }}'
+          completeTimestamp: '{{ now_time_utc }}'
           state: error
       towerJobs:
         status:
-          completeTimestamp: '{{ anarchy_run_timestamp }}'
+          completeTimestamp: '{{ now_time_utc }}'
           jobStatus: error
 
 - name: Finish action {{ anarchy_action_name }} as error

--- a/tasks/handle-action-status-error.yaml
+++ b/tasks/handle-action-status-error.yaml
@@ -7,6 +7,10 @@
       vars:
         check_status_state: error
     status:
+      actions:
+        status:
+          completeTimestamp: '{{ anarchy_run_timestamp }}'
+          state: error
       towerJobs:
         status:
           completeTimestamp: '{{ anarchy_run_timestamp }}'

--- a/tasks/handle-action-status-failed.yaml
+++ b/tasks/handle-action-status-failed.yaml
@@ -9,11 +9,11 @@
     status:
       actions:
         status:
-          completeTimestamp: '{{ anarchy_run_timestamp }}'
+          completeTimestamp: '{{ now_time_utc }}'
           state: failed
       towerJobs:
         status:
-          completeTimestamp: '{{ anarchy_run_timestamp }}'
+          completeTimestamp: '{{ now_time_utc }}'
           jobStatus: failed
 
 - name: Finish action {{ anarchy_action_name }} as failed

--- a/tasks/handle-action-status-failed.yaml
+++ b/tasks/handle-action-status-failed.yaml
@@ -7,6 +7,10 @@
       vars:
         check_status_state: failed
     status:
+      actions:
+        status:
+          completeTimestamp: '{{ anarchy_run_timestamp }}'
+          state: failed
       towerJobs:
         status:
           completeTimestamp: '{{ anarchy_run_timestamp }}'

--- a/tasks/handle-action-stop-canceled.yaml
+++ b/tasks/handle-action-stop-canceled.yaml
@@ -12,11 +12,11 @@
     status:
       actions:
         stop:
-          completeTimestamp: '{{ anarchy_run_timestamp }}'
+          completeTimestamp: '{{ now_time_utc }}'
           state: canceled
       towerJobs:
         stop:
-          completeTimestamp: '{{ anarchy_run_timestamp }}'
+          completeTimestamp: '{{ now_time_utc }}'
           jobStatus: canceled
 
 - name: Schedule stop retry for {{ anarchy_subject_name }}

--- a/tasks/handle-action-stop-canceled.yaml
+++ b/tasks/handle-action-stop-canceled.yaml
@@ -10,6 +10,10 @@
         current_state: stop-canceled
         healthy: false
     status:
+      actions:
+        stop:
+          completeTimestamp: '{{ anarchy_run_timestamp }}'
+          state: canceled
       towerJobs:
         stop:
           completeTimestamp: '{{ anarchy_run_timestamp }}'

--- a/tasks/handle-action-stop-complete.yaml
+++ b/tasks/handle-action-stop-complete.yaml
@@ -2,6 +2,10 @@
 - name: Set state stopped for {{ anarchy_subject_name }}
   anarchy_subject_update:
     status:
+      actions:
+        stop:
+          completeTimestamp: '{{ anarchy_run_timestamp }}'
+          state: successful
       towerJobs:
         stop:
           completeTimestamp: '{{ anarchy_run_timestamp }}'

--- a/tasks/handle-action-stop-complete.yaml
+++ b/tasks/handle-action-stop-complete.yaml
@@ -4,11 +4,11 @@
     status:
       actions:
         stop:
-          completeTimestamp: '{{ anarchy_run_timestamp }}'
+          completeTimestamp: '{{ now_time_utc }}'
           state: successful
       towerJobs:
         stop:
-          completeTimestamp: '{{ anarchy_run_timestamp }}'
+          completeTimestamp: '{{ now_time_utc }}'
           jobStatus: successful
 
 - when: >-

--- a/tasks/handle-action-stop-error.yaml
+++ b/tasks/handle-action-stop-error.yaml
@@ -24,11 +24,11 @@
     status:
       actions:
         stop:
-          completeTimestamp: '{{ anarchy_run_timestamp }}'
+          completeTimestamp: '{{ now_time_utc }}'
           state: error
       towerJobs:
         stop:
-          completeTimestamp: '{{ anarchy_run_timestamp }}'
+          completeTimestamp: '{{ now_time_utc }}'
           jobStatus: error
 
 - name: Schedule stop retry for {{ anarchy_subject_name }}

--- a/tasks/handle-action-stop-error.yaml
+++ b/tasks/handle-action-stop-error.yaml
@@ -22,6 +22,10 @@
         current_state: stop-error
         healthy: false
     status:
+      actions:
+        stop:
+          completeTimestamp: '{{ anarchy_run_timestamp }}'
+          state: error
       towerJobs:
         stop:
           completeTimestamp: '{{ anarchy_run_timestamp }}'

--- a/tasks/handle-action-stop-failed.yaml
+++ b/tasks/handle-action-stop-failed.yaml
@@ -24,11 +24,11 @@
     status:
       actions:
         stop:
-          completeTimestamp: '{{ anarchy_run_timestamp }}'
+          completeTimestamp: '{{ now_time_utc }}'
           state: failed
       towerJobs:
         stop:
-          completeTimestamp: '{{ anarchy_run_timestamp }}'
+          completeTimestamp: '{{ now_time_utc }}'
           jobStatus: failed
 
 - name: Schedule stop retry for {{ anarchy_subject_name }}

--- a/tasks/handle-action-stop-failed.yaml
+++ b/tasks/handle-action-stop-failed.yaml
@@ -22,6 +22,10 @@
         current_state: stop-failed
         healthy: false
     status:
+      actions:
+        stop:
+          completeTimestamp: '{{ anarchy_run_timestamp }}'
+          state: failed
       towerJobs:
         stop:
           completeTimestamp: '{{ anarchy_run_timestamp }}'

--- a/tasks/handle-action-update-canceled.yaml
+++ b/tasks/handle-action-update-canceled.yaml
@@ -10,6 +10,10 @@
         current_state: update-canceled
         healthy: false
     status:
+      actions:
+        update:
+          completeTimestamp: '{{ anarchy_run_timestamp }}'
+          state: canceled
       towerJobs:
         update:
           completeTimestamp: '{{ anarchy_run_timestamp }}'

--- a/tasks/handle-action-update-canceled.yaml
+++ b/tasks/handle-action-update-canceled.yaml
@@ -12,11 +12,11 @@
     status:
       actions:
         update:
-          completeTimestamp: '{{ anarchy_run_timestamp }}'
+          completeTimestamp: '{{ now_time_utc }}'
           state: canceled
       towerJobs:
         update:
-          completeTimestamp: '{{ anarchy_run_timestamp }}'
+          completeTimestamp: '{{ now_time_utc }}'
           jobStatus: canceled
 
 - name: Schedule update retry for {{ anarchy_subject_name }}

--- a/tasks/handle-action-update-complete.yaml
+++ b/tasks/handle-action-update-complete.yaml
@@ -8,6 +8,10 @@
       vars:
         current_state: started
     status:
+      actions:
+        update:
+          completeTimestamp: '{{ anarchy_run_timestamp }}'
+          state: successful
       towerJobs:
         start:
           completeTimestamp: '{{ anarchy_run_timestamp }}'

--- a/tasks/handle-action-update-complete.yaml
+++ b/tasks/handle-action-update-complete.yaml
@@ -10,11 +10,11 @@
     status:
       actions:
         update:
-          completeTimestamp: '{{ anarchy_run_timestamp }}'
+          completeTimestamp: '{{ now_time_utc }}'
           state: successful
       towerJobs:
         start:
-          completeTimestamp: '{{ anarchy_run_timestamp }}'
+          completeTimestamp: '{{ now_time_utc }}'
           jobStatus: successful
 
 - name: Report action successful

--- a/tasks/handle-action-update-error.yaml
+++ b/tasks/handle-action-update-error.yaml
@@ -10,6 +10,10 @@
         current_state: update-error
         healthy: false
     status:
+      actions:
+        update:
+          completeTimestamp: '{{ anarchy_run_timestamp }}'
+          state: error
       towerJobs:
         update:
           completeTimestamp: '{{ anarchy_run_timestamp }}'

--- a/tasks/handle-action-update-error.yaml
+++ b/tasks/handle-action-update-error.yaml
@@ -12,11 +12,11 @@
     status:
       actions:
         update:
-          completeTimestamp: '{{ anarchy_run_timestamp }}'
+          completeTimestamp: '{{ now_time_utc }}'
           state: error
       towerJobs:
         update:
-          completeTimestamp: '{{ anarchy_run_timestamp }}'
+          completeTimestamp: '{{ now_time_utc }}'
           jobStatus: error
 
 - name: Schedule update retry for {{ anarchy_subject_name }}

--- a/tasks/handle-action-update-failed.yaml
+++ b/tasks/handle-action-update-failed.yaml
@@ -12,11 +12,11 @@
     status:
       actions:
         update:
-          completeTimestamp: '{{ anarchy_run_timestamp }}'
+          completeTimestamp: '{{ now_time_utc }}'
           state: failed
       towerJobs:
         update:
-          completeTimestamp: '{{ anarchy_run_timestamp }}'
+          completeTimestamp: '{{ now_time_utc }}'
           jobStatus: failed
 
 - name: Schedule update retry for {{ anarchy_subject_name }}

--- a/tasks/handle-action-update-failed.yaml
+++ b/tasks/handle-action-update-failed.yaml
@@ -10,6 +10,10 @@
         current_state: update-failed
         healthy: false
     status:
+      actions:
+        update:
+          completeTimestamp: '{{ anarchy_run_timestamp }}'
+          state: failed
       towerJobs:
         update:
           completeTimestamp: '{{ anarchy_run_timestamp }}'

--- a/tasks/run-provision.yaml
+++ b/tasks/run-provision.yaml
@@ -45,6 +45,11 @@
           current_state: started
           healthy: true
           provision_data: '{{ action_provision_data | default(omit, true) }}'
+      status:
+        actions:
+          provision:
+            completeTimestamp: '{{ anarchy_run_timestamp }}'
+            status: successful
 
   - name: Report action successful when deployer is disabled
     anarchy_finish_action:

--- a/tasks/run-provision.yaml
+++ b/tasks/run-provision.yaml
@@ -48,7 +48,7 @@
       status:
         actions:
           provision:
-            completeTimestamp: '{{ anarchy_run_timestamp }}'
+            completeTimestamp: "{{ now_time_utc }}"
             status: successful
 
   - name: Report action successful when deployer is disabled

--- a/tasks/run-provision.yaml
+++ b/tasks/run-provision.yaml
@@ -4,6 +4,8 @@
   include_tasks: sandbox_get.yaml
 
 - name: Run deployer provision {{ anarchy_subject_name }}
+  when: >-
+    not __meta__.deployer.actions.provision.disable | default(false) | bool
   vars:
     new_subject_state: provisioning
     job_template_playbook: "{{ deployer_entry_points.provision }}"

--- a/tasks/run-provision.yaml
+++ b/tasks/run-provision.yaml
@@ -23,6 +23,16 @@
     file: check-run-tower-job.yaml
 
 - name: Schedule check for provision of {{ anarchy_subject_name }}
+  when: >-
+    not __meta__.deployer.actions.provision.disable | default(false) | bool
   anarchy_continue_action:
     after: "{{ job_check_interval }}"
+
+- name: Handle action complete for {{ anarchy_subject_name }} when deployer is disabled
+  when: >-
+    sandbox_api_in_use | bool and
+    __meta__.deployer.actions.provision.disable | default(false) | bool
+  include_tasks: handle-action-provision-complete.yaml
+  vars:
+    action_provision_data: "{{ dynamic_job_vars | extract_sandboxes_vars | default({}) }}"
 ...

--- a/tasks/run-provision.yaml
+++ b/tasks/run-provision.yaml
@@ -45,8 +45,6 @@
           current_state: started
           healthy: true
           provision_data: '{{ action_provision_data | default(omit, true) }}'
-          provision_message_body: '{{ action_provision_message_body | default(omit, true) }}'
-          provision_messages: '{{ action_provision_messages | default(omit, true) }}'
 
   - name: Report action successful when deployer is disabled
     anarchy_finish_action:

--- a/tasks/run-provision.yaml
+++ b/tasks/run-provision.yaml
@@ -34,5 +34,5 @@
     __meta__.deployer.actions.provision.disable | default(false) | bool
   include_tasks: handle-action-provision-complete.yaml
   vars:
-    action_provision_data: "{{ dynamic_job_vars | extract_sandboxes_vars | default({}) }}"
+    action_provision_data: "{{ extracted_sandboxes_vars | default({}) }}"
 ...

--- a/tasks/run-provision.yaml
+++ b/tasks/run-provision.yaml
@@ -32,7 +32,23 @@
   when: >-
     sandbox_api_in_use | bool and
     __meta__.deployer.actions.provision.disable | default(false) | bool
-  include_tasks: handle-action-provision-complete.yaml
-  vars:
-    action_provision_data: "{{ extracted_sandboxes_vars | default({}) }}"
+  block:
+  - name: Set state started for {{ anarchy_subject_name }} when deployer is disabled
+    vars:
+      action_provision_data: "{{ extracted_sandboxes_vars | default({}) }}"
+    anarchy_subject_update:
+      metadata:
+        labels:
+          state: started
+      spec:
+        vars:
+          current_state: started
+          healthy: true
+          provision_data: '{{ action_provision_data | default(omit, true) }}'
+          provision_message_body: '{{ action_provision_message_body | default(omit, true) }}'
+          provision_messages: '{{ action_provision_messages | default(omit, true) }}'
+
+  - name: Report action successful when deployer is disabled
+    anarchy_finish_action:
+      state: successful
 ...

--- a/tasks/run-tower-job.yaml
+++ b/tasks/run-tower-job.yaml
@@ -192,6 +192,9 @@
         current_state: "{{ new_subject_state | default(current_state) }}"
         check_status_state: "{{ new_check_status_state | default(check_status_state) }}"
     status:
+      actions:
+        provision:
+          startTimestamp: '{{ anarchy_run_timestamp }}'
       towerJobs: >-
         {{ {
            anarchy_action_config_name: {

--- a/tasks/sandbox_api_book.yaml
+++ b/tasks/sandbox_api_book.yaml
@@ -119,8 +119,12 @@
       vars:
         job_vars: "{{ r_placement.json | extract_sandboxes_vars(creds=False) }}"
     status:
+      actions:
+        provision:
+          startTimestamp: '{{ anarchy_run_timestamp }}'
       sandboxAPIJobs:
         provision:
           provisionTimestamp: "{{ now_time_utc }}"
+
           httpStatus: "{{ r_placement.status }}"
 ...

--- a/tasks/sandbox_api_book.yaml
+++ b/tasks/sandbox_api_book.yaml
@@ -107,6 +107,8 @@
       {{ vars.dynamic_job_vars
       | default({})
       | combine(r_placement.json | extract_sandboxes_vars, recursive=True) }}
+    extracted_sandboxes_vars: >-
+      {{ r_placement.json | extract_sandboxes_vars }}
 
 - name: Set sandbox for {{ anarchy_subject_name }}
   anarchy_subject_update:
@@ -116,4 +118,9 @@
     spec:
       vars:
         job_vars: "{{ r_placement.json | extract_sandboxes_vars(creds=False) }}"
+    status:
+      sandboxAPIJobs:
+        provision:
+          provisionTimestamp: "{{ now_time_utc }}"
+          httpStatus: "{{ r_placement.status }}"
 ...

--- a/tasks/sandbox_api_book.yaml
+++ b/tasks/sandbox_api_book.yaml
@@ -124,7 +124,6 @@
           startTimestamp: '{{ anarchy_run_timestamp }}'
       sandboxAPIJobs:
         provision:
-          provisionTimestamp: "{{ now_time_utc }}"
-
+          startTimestamp: "{{ now_time_utc }}"
           httpStatus: "{{ r_placement.status }}"
 ...

--- a/tasks/sandbox_api_get.yaml
+++ b/tasks/sandbox_api_get.yaml
@@ -14,7 +14,7 @@
     or r_get_placement.json.http_code == 404
 
 - name: Finish action {{ anarchy_action_name }} as failed
-  when: r_get_placement.json.status == 'error'
+  when: r_get_placement.json.status | default('unknown') == 'error'
   block:
   - name: Debug placement error
     debug:

--- a/tasks/sandbox_api_get.yaml
+++ b/tasks/sandbox_api_get.yaml
@@ -9,7 +9,9 @@
   retries: "{{ sandbox_api_retries }}"
   delay: "{{ sandbox_api_delay }}"
   register: r_get_placement
-  until: r_get_placement.json.status | default('unknown') in ['success', 'error']
+  until: >-
+    r_get_placement.json.status | default('unknown') in ['success', 'error']
+    or r_get_placement.json.http_code == 404
 
 - name: Finish action {{ anarchy_action_name }} as failed
   when: r_get_placement.json.status == 'error'

--- a/tasks/sandbox_api_start.yaml
+++ b/tasks/sandbox_api_start.yaml
@@ -45,7 +45,7 @@
       or r_request.json.status | default('unknown') == 'error'
     until: >-
       r_request is succeeded
-      and r_request.json.status in ["success", "error"]
+      and r_request.json.status | default('unknown')  in ["success", "error"]
 
   - when: r_request.json.status == "success"
     block:

--- a/tasks/sandbox_api_stop.yaml
+++ b/tasks/sandbox_api_stop.yaml
@@ -46,7 +46,7 @@
       or r_request.json.status | default('unknown') == 'error'
     until: >-
       r_request is succeeded
-      and r_request.json.status in ["success", "error"]
+      and r_request.json.status | default('unknown') in ["success", "error"]
 
   - when: r_request.json.status == "success"
     block:
@@ -81,6 +81,10 @@
           vars:
             current_state: stop-error
         status:
+          actions:
+            stop:
+              completeTimestamp: '{{ anarchy_run_timestamp }}'
+              state: error
           sandboxAPIJobs:
             stop:
               completeTimestamp: "{{ now_time_utc }}"
@@ -103,6 +107,10 @@
           current_state: stop-error
           healthy: false
       status:
+        actions:
+          stop:
+            completeTimestamp: '{{ anarchy_run_timestamp }}'
+            state: error
         sandboxAPIJobs:
           stop:
             completeTimestamp: "{{ now_time_utc }}"

--- a/tasks/sandbox_api_stop.yaml
+++ b/tasks/sandbox_api_stop.yaml
@@ -83,7 +83,7 @@
         status:
           actions:
             stop:
-              completeTimestamp: '{{ anarchy_run_timestamp }}'
+              completeTimestamp: '{{ now_time_utc }}'
               state: error
           sandboxAPIJobs:
             stop:
@@ -109,7 +109,7 @@
       status:
         actions:
           stop:
-            completeTimestamp: '{{ anarchy_run_timestamp }}'
+            completeTimestamp: '{{ now_time_utc }}'
             state: error
         sandboxAPIJobs:
           stop:


### PR DESCRIPTION
This PR allows the deployer to be disabled entirely.
The goal is to be able to use the sandbox API when it is enough like in certain situation: OCP Blank Namespace for example

* Report new `status.actions.provision.startTimestamp`  and `status.actions.provision.completeTimestamp` in AnarchySubject
* use `now_time_utc` for all completeTimestamp instead of the anarchy timestamp as it's in the past.
