### PR TITLE
Support SCM reference catalog parameter

### DIFF
--- a/defaults/main.yaml
+++ b/defaults/main.yaml
@@ -224,3 +224,6 @@ sandbox_api_resources: >-
   {{ lookup('templated_var', __meta__.sandboxes | to_json | from_json)
   if __meta__.sandboxes is defined else
   sandbox_api_resources_default }}
+
+# Support for SCM reference catalog parameter
+deployer_scm_ref: "{{ scm_ref | default(__meta__.deployer.scm_ref) }}"

--- a/tasks/run-tower-job.yaml
+++ b/tasks/run-tower-job.yaml
@@ -38,7 +38,7 @@
 - name: Set __project_scm_ref
   set_fact:
     __project_scm_ref: >-
-      {{ __meta__.deployer.scm_ref | default(
+      {{ deployer_scm_ref | default(
         lookup('git_tag_prefix', __meta__.deployer.git_tag_prefix, git_repo=__meta__.deployer.scm_url)
         if __meta__.deployer.git_tag_prefix is defined else 'main'
       ) }}
@@ -109,7 +109,7 @@
         {{ job_extra_vars
          | insert_unvault_string
          | combine(set_output_dir | bool | ternary({"output_dir": __output_dir}, {}))
-         | combine({__meta__.deployer.scm_ref_var: __project_scm_ref} if __meta__.deployer.scm_ref_var is defined else {})
+         | combine({deployer_scm_ref_var: __project_scm_ref} if __meta__.deployer.scm_ref_var is defined else {})
         }}
       playbook: "{{ job_template_playbook }}"
       project: "{{ __project_name }}"
@@ -140,7 +140,7 @@
         {{ job_extra_vars
          | insert_unvault_string
          | combine(set_output_dir | bool | ternary({"output_dir": __output_dir}, {}))
-         | combine({__meta__.deployer.scm_ref_var: __project_scm_ref} if __meta__.deployer.scm_ref_var is defined else {})
+         | combine({deployer_scm_ref_var: __project_scm_ref} if __meta__.deployer.scm_ref_var is defined else {})
         }}
       playbook: "{{ job_template_playbook }}"
       project: "{{ __project_name }}"


### PR DESCRIPTION
- Add deployer_scm_ref variable in defaults/main.yaml
- Maps scm_ref catalog parameter to deployer_scm_ref
- Update run-tower-job.yaml to use deployer_scm_ref instead of __meta__.deployer.scm_ref
- Enables users to select SCM reference (branch/tag/commit) via catalog parameter

This allows agnosticv catalog parameters with 'variable: scm_ref' to dynamically control the SCM reference used for deployment.